### PR TITLE
Feature/cheat start position

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,9 @@
     </parent>
     <groupId>at.aau.serg</groupId>
     <artifactId>ScotlandYard-Server</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
-    <name>WebSocketDemo-Server</name>
-    <description>WebSocketDemo-Server</description>
+    <version>v1.0.0</version>
+    <name>ScotlandYard-Server</name>
+    <description>ScotlandYard-Server</description>
     <properties>
         <java.version>21</java.version>
         <sonar.organization>se2-s26-gruppe2-scotlandyard</sonar.organization>

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
@@ -3,16 +3,22 @@ package at.aau.serg.websocketdemoserver.dtos.game;
 import at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class GameStateDto {
     private String gameId;
     private int currentRound;
     private TurnType currentPhase;
+    /** Convenience flag: true when it is Mr. X's turn. */
+    private boolean isMrXPhase;
+    /** Convenience flag: true when it is the detectives' turn. */
+    private boolean isDetectivesPhase;
     private Map<String, Integer> detectivePositions;
     private Integer mrXPosition;
     private boolean doubleMoveActive;

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
@@ -15,10 +15,6 @@ public class GameStateDto {
     private String gameId;
     private int currentRound;
     private TurnType currentPhase;
-    /** Convenience flag: true when it is Mr. X's turn. */
-    private boolean isMrXPhase;
-    /** Convenience flag: true when it is the detectives' turn. */
-    private boolean isDetectivesPhase;
     private Map<String, Integer> detectivePositions;
     private Integer mrXPosition;
     private boolean doubleMoveActive;

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/StartPositionConfirmRequest.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/StartPositionConfirmRequest.java
@@ -1,0 +1,28 @@
+package at.aau.serg.websocketdemoserver.dtos.game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * STOMP message sent by the client to confirm its chosen start position.
+ *
+ * <p>Destination: {@code /app/game/start-position/confirm}
+ *
+ * <p>The client (frontend spinner) generates the position locally and sends
+ * it here for server-side validation and persistence.  The server validates
+ * that the position is in range (1–199) and not already occupied, then
+ * broadcasts the updated {@code GameStateDto} to
+ * {@code /topic/game/{gameId}/movements} so every player on the board
+ * screen sees the new position immediately.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StartPositionConfirmRequest {
+    private String gameId;
+    private String playerId;
+    /** Chosen start position, must be in range 1–199. */
+    private int startPosition;
+}
+

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/StartPositionRequest.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/StartPositionRequest.java
@@ -1,14 +1,40 @@
 package at.aau.serg.websocketdemoserver.dtos.game;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Request DTO for assigning a start position to a player.
+ *
+ * The optional field {@code selectedStartPosition} supports the cheat/debug
+ * feature: when the spin-wheel is used manually the chosen position (1–199)
+ * is submitted here.  When {@code null} the server falls back to its random
+ * assignment logic (unchanged behaviour).
+ */
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class StartPositionRequest {
+
     private String gameId;
     private String playerId;
-}
 
+    /**
+     * Optional manually-selected start position (cheat/debug feature).
+     * Valid range: 1–199.  {@code null} triggers the automatic random fallback.
+     */
+    private Integer selectedStartPosition;
+
+    /** Backward-compatible 2-arg constructor – no manual position. */
+    public StartPositionRequest(String gameId, String playerId) {
+        this.gameId = gameId;
+        this.playerId = playerId;
+        this.selectedStartPosition = null;
+    }
+
+    /** Full 3-arg constructor used when a manual start position is supplied. */
+    public StartPositionRequest(String gameId, String playerId, Integer selectedStartPosition) {
+        this.gameId = gameId;
+        this.playerId = playerId;
+        this.selectedStartPosition = selectedStartPosition;
+    }
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
@@ -152,14 +152,15 @@ public class GameState {
      * <ul>
      *   <li>Player must exist.</li>
      *   <li>Position must be in range 1–199 (board stations).</li>
-     *   <li>Position must not already be occupied by a <em>different</em> player.</li>
+     *   <li>If the requested position is already occupied by a <em>different</em> player,
+     *       a random free position is assigned instead (conflict-free fallback).</li>
      * </ul>
      *
      * @param playerId      ID of the confirming player
      * @param startPosition chosen start position (1–199)
-     * @return the confirmed position
+     * @return the final confirmed position (may differ from {@code startPosition} if taken)
      * @throws IllegalArgumentException if player not found or position out of range
-     * @throws IllegalStateException    if position is already taken by another player
+     * @throws IllegalStateException    if no free positions are available
      */
     public int confirmStartPosition(String playerId, int startPosition) {
         if (!players.containsKey(playerId)) {
@@ -169,13 +170,27 @@ public class GameState {
             throw new IllegalArgumentException(
                     "Start position must be between 1 and 199, got: " + startPosition);
         }
-        // Check if another player already occupies this position
-        for (Map.Entry<String, Integer> entry : playerPositions.entrySet()) {
-            if (!entry.getKey().equals(playerId) && entry.getValue().equals(startPosition)) {
-                throw new IllegalStateException(
-                        "Position " + startPosition + " is already taken by another player");
+
+        // Check if another player already occupies this position → fall back to random free slot
+        boolean taken = playerPositions.entrySet().stream()
+                .anyMatch(e -> !e.getKey().equals(playerId) && e.getValue().equals(startPosition));
+
+        if (taken) {
+            List<Integer> available = new ArrayList<>();
+            for (int i = 1; i <= 199; i++) available.add(i);
+            // Remove positions held by other players (keep player's own slot free for reassignment)
+            playerPositions.forEach((pid, pos) -> {
+                if (!pid.equals(playerId)) available.remove(pos);
+            });
+            if (available.isEmpty()) {
+                throw new IllegalStateException("No free start positions available");
             }
+            Collections.shuffle(available, RANDOM);
+            int fallback = available.getFirst();
+            playerPositions.put(playerId, fallback);
+            return fallback;
         }
+
         playerPositions.put(playerId, startPosition);
         return startPosition;
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
@@ -89,6 +89,110 @@ public class GameState {
         return assignedPosition;
     }
 
+    /**
+     * Assigns a start position to the given player.
+     *
+     * <p>Cheat/debug variant: when {@code selectedStartPosition} is non-null the
+     * supplied value is used instead of the random fallback.  The position is
+     * validated before it is applied:
+     * <ul>
+     *   <li>must be in range 1–199</li>
+     *   <li>must not already be occupied by another player</li>
+     * </ul>
+     * If {@code selectedStartPosition} is {@code null} the call delegates to the
+     * standard {@link #assignStartPosition(String)} method, preserving the
+     * existing automatic behaviour for clients that do not send the field.
+     *
+     * @param playerId              the ID of the player to position
+     * @param selectedStartPosition optional manually chosen position, or {@code null}
+     * @return the assigned start position
+     * @throws IllegalArgumentException if the player does not exist or the
+     *                                  position is out of range
+     * @throws IllegalStateException    if the position is already taken
+     */
+    public int assignStartPosition(String playerId, Integer selectedStartPosition) {
+        // null → standard random fallback (backward compat)
+        if (selectedStartPosition == null) {
+            return assignStartPosition(playerId);
+        }
+
+        if (!players.containsKey(playerId)) {
+            throw new IllegalArgumentException("Player not found: " + playerId);
+        }
+
+        // Player already has a position → return it unchanged
+        Integer existingPosition = playerPositions.get(playerId);
+        if (existingPosition != null) {
+            return existingPosition;
+        }
+
+        // Range validation
+        if (selectedStartPosition < 1 || selectedStartPosition > 199) {
+            throw new IllegalArgumentException(
+                    "Selected start position must be between 1 and 199, got: " + selectedStartPosition);
+        }
+
+        // Occupancy validation
+        if (playerPositions.containsValue(selectedStartPosition)) {
+            throw new IllegalStateException(
+                    "Position " + selectedStartPosition + " is already taken by another player");
+        }
+
+        playerPositions.put(playerId, selectedStartPosition);
+        return selectedStartPosition;
+    }
+
+    /**
+     * Confirms a client-chosen start position (spinner confirm flow).
+     *
+     * <p>Unlike {@link #assignStartPosition(String, Integer)} this method always
+     * writes the supplied position (it does not return an already-stored value
+     * unchanged), so the client can correct its selection before the game
+     * actually starts.  Validation rules:
+     * <ul>
+     *   <li>Player must exist.</li>
+     *   <li>Position must be in range 1–199 (board stations).</li>
+     *   <li>Position must not already be occupied by a <em>different</em> player.</li>
+     * </ul>
+     *
+     * @param playerId      ID of the confirming player
+     * @param startPosition chosen start position (1–199)
+     * @return the confirmed position
+     * @throws IllegalArgumentException if player not found or position out of range
+     * @throws IllegalStateException    if position is already taken by another player
+     */
+    public int confirmStartPosition(String playerId, int startPosition) {
+        if (!players.containsKey(playerId)) {
+            throw new IllegalArgumentException("Player not found: " + playerId);
+        }
+        if (startPosition < 1 || startPosition > 199) {
+            throw new IllegalArgumentException(
+                    "Start position must be between 1 and 199, got: " + startPosition);
+        }
+        // Check if another player already occupies this position
+        for (Map.Entry<String, Integer> entry : playerPositions.entrySet()) {
+            if (!entry.getKey().equals(playerId) && entry.getValue().equals(startPosition)) {
+                throw new IllegalStateException(
+                        "Position " + startPosition + " is already taken by another player");
+            }
+        }
+        playerPositions.put(playerId, startPosition);
+        return startPosition;
+    }
+
+    /**
+     * Returns {@code true} when every registered player has a confirmed start position.
+     * Used to detect when the board can become fully interactive.
+     */
+    public boolean allPlayersHaveStartPosition() {
+        for (String playerId : players.keySet()) {
+            if (!playerPositions.containsKey(playerId)) {
+                return false;
+            }
+        }
+        return !players.isEmpty();
+    }
+
     public boolean activateDoubleMove() {
         Player player = players.get(mrXId);
 

--- a/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
@@ -13,8 +13,6 @@ public class GameStateMapper {
                 gameState.getGameId(),
                 gameState.getCurrentRound(),
                 phase,
-                phase == at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType.MRX,
-                phase == at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType.DETECTIVES,
                 gameState.getDetectivePositions(),
                 gameState.getMrXPosition(),
                 gameState.getRoundController().isDoubleMoveActive(),

--- a/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
@@ -8,11 +8,10 @@ public class GameStateMapper {
     private GameStateMapper() {}
 
     public static GameStateDto toDto(GameState gameState) {
-        at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType phase = gameState.getCurrentPhase();
         return new GameStateDto(
                 gameState.getGameId(),
                 gameState.getCurrentRound(),
-                phase,
+                gameState.getCurrentPhase(),
                 gameState.getDetectivePositions(),
                 gameState.getMrXPosition(),
                 gameState.getRoundController().isDoubleMoveActive(),

--- a/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
@@ -8,10 +8,13 @@ public class GameStateMapper {
     private GameStateMapper() {}
 
     public static GameStateDto toDto(GameState gameState) {
+        at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType phase = gameState.getCurrentPhase();
         return new GameStateDto(
                 gameState.getGameId(),
                 gameState.getCurrentRound(),
-                gameState.getCurrentPhase(),
+                phase,
+                phase == at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType.MRX,
+                phase == at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType.DETECTIVES,
                 gameState.getDetectivePositions(),
                 gameState.getMrXPosition(),
                 gameState.getRoundController().isDoubleMoveActive(),

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -1,6 +1,7 @@
 package at.aau.serg.websocketdemoserver.websocket.broker;
 
 import at.aau.serg.websocketdemoserver.dtos.game.GameStateDto;
+import at.aau.serg.websocketdemoserver.dtos.game.StartPositionConfirmRequest;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionRequest;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionResponse;
 import at.aau.serg.websocketdemoserver.dtos.StompMessage;
@@ -317,11 +318,60 @@ public class WebSocketBrokerController {
         }
 
         try {
-            int position = gameState.assignStartPosition(playerId);
+            int position = gameState.assignStartPosition(playerId, request.getSelectedStartPosition());
             messagingTemplate.convertAndSend(topic,
                     new StartPositionResponse("START_POSITION_ASSIGNED", gameId, playerId, position, null));
         } catch (Exception e) {
             messagingTemplate.convertAndSend(topic,
+                    new StartPositionResponse("ERROR", gameId, playerId, null, e.getMessage()));
+        }
+    }
+
+    /**
+     * Confirms a client-chosen start position (spinner confirm flow).
+     *
+     * <p>Destination: {@code /app/game/start-position/confirm}
+     * <p>Payload: {@link StartPositionConfirmRequest} with {@code gameId}, {@code playerId},
+     * {@code startPosition} (int 1–199).
+     *
+     * <p>On success the updated {@link GameStateDto} is broadcast to
+     * {@code /topic/game/{gameId}/movements} so all players see the confirmed position
+     * on the game board immediately.  An optional "all confirmed" broadcast is included
+     * once every player has set their start position.
+     *
+     * <p>On validation error a {@link StartPositionResponse} with {@code type="ERROR"}
+     * is sent to the player-specific topic
+     * {@code /topic/game/{gameId}/player/{playerId}/start-position}.
+     */
+    @MessageMapping("/game/start-position/confirm")
+    public void handleConfirmStartPosition(StartPositionConfirmRequest request) {
+        String gameId  = request.getGameId();
+        String playerId = request.getPlayerId();
+        String errorTopic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
+
+        GameState gameState = gameController.getGame(gameId);
+        if (gameState == null) {
+            messagingTemplate.convertAndSend(errorTopic,
+                    new StartPositionResponse("ERROR", gameId, playerId, null, "Game not found"));
+            return;
+        }
+
+        try {
+            int confirmedPosition = gameState.confirmStartPosition(playerId, request.getStartPosition());
+            // Broadcast updated board state to all players on the game board screen
+            broadcastGameState(gameId, gameState);
+
+            // Additionally notify the confirming player with an explicit ack
+            messagingTemplate.convertAndSend(errorTopic,
+                    new StartPositionResponse("START_POSITION_CONFIRMED", gameId, playerId,
+                            confirmedPosition, null));
+
+            // If all players have confirmed, send a dedicated "all ready" broadcast
+            if (gameState.allPlayersHaveStartPosition()) {
+                broadcastGameState(gameId, gameState);
+            }
+        } catch (Exception e) {
+            messagingTemplate.convertAndSend(errorTopic,
                     new StartPositionResponse("ERROR", gameId, playerId, null, e.getMessage()));
         }
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -306,8 +306,23 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/game/start-position/request")
     public void handleStartPositionRequest(StartPositionRequest request) {
+        if (request == null) {
+            return; // no recipient address available – silently ignore
+        }
         String gameId = request.getGameId();
         String playerId = request.getPlayerId();
+
+        if (gameId == null || gameId.isBlank()) {
+            messagingTemplate.convertAndSend("/topic/game/error",
+                    new StartPositionResponse("ERROR", null, playerId, null, "gameId must not be blank"));
+            return;
+        }
+        if (playerId == null || playerId.isBlank()) {
+            messagingTemplate.convertAndSend(TOPIC_GAME + gameId + "/player/unknown/start-position",
+                    new StartPositionResponse("ERROR", gameId, null, null, "playerId must not be blank"));
+            return;
+        }
+
         String topic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
 
         GameState gameState = gameController.getGame(gameId);

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -321,6 +321,8 @@ public class WebSocketBrokerController {
             int position = gameState.assignStartPosition(playerId, request.getSelectedStartPosition());
             messagingTemplate.convertAndSend(topic,
                     new StartPositionResponse("START_POSITION_ASSIGNED", gameId, playerId, position, null));
+            // Broadcast the updated board state so every client renders the new figure immediately
+            broadcastGameState(gameId, gameState);
         } catch (Exception e) {
             messagingTemplate.convertAndSend(topic,
                     new StartPositionResponse("ERROR", gameId, playerId, null, e.getMessage()));

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -351,14 +351,15 @@ public class WebSocketBrokerController {
      * <p>Payload: {@link StartPositionConfirmRequest} with {@code gameId}, {@code playerId},
      * {@code startPosition} (int 1–199).
      *
-     * <p>On success the updated {@link GameStateDto} is broadcast to
-     * {@code /topic/game/{gameId}/movements} so all players see the confirmed position
-     * on the game board immediately.  An optional "all confirmed" broadcast is included
-     * once every player has set their start position.
-     *
-     * <p>On validation error a {@link StartPositionResponse} with {@code type="ERROR"}
-     * is sent to the player-specific topic
+     * <p>The server validates that the position is in range (1–199) and not already
+     * occupied.  If the requested position is taken a random free slot is assigned
+     * automatically (conflict-free fallback).  The final position is sent
+     * <em>exclusively</em> to the requesting player via their personal topic
      * {@code /topic/game/{gameId}/player/{playerId}/start-position}.
+     * No board-state broadcast is sent so other players cannot infer positions.
+     *
+     * <p>On validation error (out-of-range, player not found, etc.) a
+     * {@link StartPositionResponse} with {@code type="ERROR"} is sent to the same topic.
      */
     @MessageMapping("/game/start-position/confirm")
     public void handleConfirmStartPosition(StartPositionConfirmRequest request) {
@@ -379,31 +380,23 @@ public class WebSocketBrokerController {
             return;
         }
 
-        String errorTopic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
+        String playerTopic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
 
         GameState gameState = gameController.getGame(gameId);
         if (gameState == null) {
-            messagingTemplate.convertAndSend(errorTopic,
+            messagingTemplate.convertAndSend(playerTopic,
                     new StartPositionResponse("ERROR", gameId, playerId, null, "Game not found"));
             return;
         }
 
         try {
             int confirmedPosition = gameState.confirmStartPosition(playerId, request.getStartPosition());
-            // Broadcast updated board state to all players on the game board screen
-            broadcastGameState(gameId, gameState);
-
-            // Additionally notify the confirming player with an explicit ack
-            messagingTemplate.convertAndSend(errorTopic,
+            // Respond ONLY to the requesting player – no board-state broadcast
+            messagingTemplate.convertAndSend(playerTopic,
                     new StartPositionResponse("START_POSITION_CONFIRMED", gameId, playerId,
                             confirmedPosition, null));
-
-            // If all players have confirmed, send a dedicated "all ready" broadcast
-            if (gameState.allPlayersHaveStartPosition()) {
-                broadcastGameState(gameId, gameState);
-            }
         } catch (Exception e) {
-            messagingTemplate.convertAndSend(errorTopic,
+            messagingTemplate.convertAndSend(playerTopic,
                     new StartPositionResponse("ERROR", gameId, playerId, null, e.getMessage()));
         }
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -362,8 +362,23 @@ public class WebSocketBrokerController {
      */
     @MessageMapping("/game/start-position/confirm")
     public void handleConfirmStartPosition(StartPositionConfirmRequest request) {
+        if (request == null) {
+            return; // no recipient address available – silently ignore
+        }
         String gameId  = request.getGameId();
         String playerId = request.getPlayerId();
+
+        if (gameId == null || gameId.isBlank()) {
+            messagingTemplate.convertAndSend("/topic/game/error",
+                    new StartPositionResponse("ERROR", null, playerId, null, "gameId must not be blank"));
+            return;
+        }
+        if (playerId == null || playerId.isBlank()) {
+            messagingTemplate.convertAndSend(TOPIC_GAME + gameId + "/player/unknown/start-position",
+                    new StartPositionResponse("ERROR", gameId, null, null, "playerId must not be blank"));
+            return;
+        }
+
         String errorTopic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
 
         GameState gameState = gameController.getGame(gameId);

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
@@ -11,14 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GameStateDtoTest {
 
     private GameStateDto buildDto(String gameId, int round, TurnType phase) {
-        boolean mrxPhase = phase == TurnType.MRX;
-        boolean detPhase = phase == TurnType.DETECTIVES;
         return new GameStateDto(
                 gameId,
                 round,
                 phase,
-                mrxPhase,
-                detPhase,
                 Map.of("det1", 10),
                 99,
                 false,
@@ -87,29 +83,8 @@ class GameStateDtoTest {
 
     @Test
     void testNullMrXPosition() {
-        GameStateDto dto = new GameStateDto("g1", 1, TurnType.MRX, true, false,
+        GameStateDto dto = new GameStateDto("g1", 1, TurnType.MRX,
                 Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of());
         assertThat(dto.getMrXPosition()).isNull();
-    }
-
-    @Test
-    void testIsMrXPhase_trueWhenMrXPhase() {
-        GameStateDto dto = buildDto("g1", 1, TurnType.MRX);
-        assertThat(dto.isMrXPhase()).isTrue();
-        assertThat(dto.isDetectivesPhase()).isFalse();
-    }
-
-    @Test
-    void testIsDetectivesPhase_trueWhenDetectivesPhase() {
-        GameStateDto dto = buildDto("g1", 1, TurnType.DETECTIVES);
-        assertThat(dto.isDetectivesPhase()).isTrue();
-        assertThat(dto.isMrXPhase()).isFalse();
-    }
-
-    @Test
-    void testNoArgsConstructorDefaultsPhaseFlags() {
-        GameStateDto dto = new GameStateDto();
-        assertThat(dto.isMrXPhase()).isFalse();
-        assertThat(dto.isDetectivesPhase()).isFalse();
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
@@ -11,10 +11,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GameStateDtoTest {
 
     private GameStateDto buildDto(String gameId, int round, TurnType phase) {
+        boolean mrxPhase = phase == TurnType.MRX;
+        boolean detPhase = phase == TurnType.DETECTIVES;
         return new GameStateDto(
                 gameId,
                 round,
                 phase,
+                mrxPhase,
+                detPhase,
                 Map.of("det1", 10),
                 99,
                 false,
@@ -83,8 +87,29 @@ class GameStateDtoTest {
 
     @Test
     void testNullMrXPosition() {
-        GameStateDto dto = new GameStateDto("g1", 1, TurnType.MRX, Map.of(), null, false, 1,
-                Map.of(), Map.of(), List.of(), Map.of());
+        GameStateDto dto = new GameStateDto("g1", 1, TurnType.MRX, true, false,
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of());
         assertThat(dto.getMrXPosition()).isNull();
+    }
+
+    @Test
+    void testIsMrXPhase_trueWhenMrXPhase() {
+        GameStateDto dto = buildDto("g1", 1, TurnType.MRX);
+        assertThat(dto.isMrXPhase()).isTrue();
+        assertThat(dto.isDetectivesPhase()).isFalse();
+    }
+
+    @Test
+    void testIsDetectivesPhase_trueWhenDetectivesPhase() {
+        GameStateDto dto = buildDto("g1", 1, TurnType.DETECTIVES);
+        assertThat(dto.isDetectivesPhase()).isTrue();
+        assertThat(dto.isMrXPhase()).isFalse();
+    }
+
+    @Test
+    void testNoArgsConstructorDefaultsPhaseFlags() {
+        GameStateDto dto = new GameStateDto();
+        assertThat(dto.isMrXPhase()).isFalse();
+        assertThat(dto.isDetectivesPhase()).isFalse();
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/StartPositionDtosTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/StartPositionDtosTest.java
@@ -13,6 +13,7 @@ class StartPositionDtosTest {
         StartPositionRequest req = new StartPositionRequest();
         assertThat(req.getGameId()).isNull();
         assertThat(req.getPlayerId()).isNull();
+        assertThat(req.getSelectedStartPosition()).isNull();
     }
 
     @Test
@@ -20,6 +21,15 @@ class StartPositionDtosTest {
         StartPositionRequest req = new StartPositionRequest("game-1", "player-1");
         assertThat(req.getGameId()).isEqualTo("game-1");
         assertThat(req.getPlayerId()).isEqualTo("player-1");
+        assertThat(req.getSelectedStartPosition()).isNull();
+    }
+
+    @Test
+    void testStartPositionRequestThreeArgConstructor() {
+        StartPositionRequest req = new StartPositionRequest("game-1", "player-1", 42);
+        assertThat(req.getGameId()).isEqualTo("game-1");
+        assertThat(req.getPlayerId()).isEqualTo("player-1");
+        assertThat(req.getSelectedStartPosition()).isEqualTo(42);
     }
 
     @Test
@@ -27,9 +37,21 @@ class StartPositionDtosTest {
         StartPositionRequest req = new StartPositionRequest();
         req.setGameId("game-1");
         req.setPlayerId("player-1");
+        req.setSelectedStartPosition(99);
 
         assertThat(req.getGameId()).isEqualTo("game-1");
         assertThat(req.getPlayerId()).isEqualTo("player-1");
+        assertThat(req.getSelectedStartPosition()).isEqualTo(99);
+    }
+
+    @Test
+    void testStartPositionRequestSettersAndGetters_nullSelectedPosition() {
+        StartPositionRequest req = new StartPositionRequest();
+        req.setGameId("game-1");
+        req.setPlayerId("player-1");
+        req.setSelectedStartPosition(null);
+
+        assertThat(req.getSelectedStartPosition()).isNull();
     }
 
     @Test
@@ -37,6 +59,17 @@ class StartPositionDtosTest {
         StartPositionRequest r1 = new StartPositionRequest("game-1", "player-1");
         StartPositionRequest r2 = new StartPositionRequest("game-1", "player-1");
         StartPositionRequest r3 = new StartPositionRequest("game-2", "player-2");
+
+        assertThat(r1).isEqualTo(r2);
+        assertThat(r1.hashCode()).isEqualTo(r2.hashCode());
+        assertThat(r1).isNotEqualTo(r3);
+    }
+
+    @Test
+    void testStartPositionRequestEqualsAndHashCode_withSelectedPosition() {
+        StartPositionRequest r1 = new StartPositionRequest("game-1", "player-1", 50);
+        StartPositionRequest r2 = new StartPositionRequest("game-1", "player-1", 50);
+        StartPositionRequest r3 = new StartPositionRequest("game-1", "player-1", 51);
 
         assertThat(r1).isEqualTo(r2);
         assertThat(r1.hashCode()).isEqualTo(r2.hashCode());

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
@@ -688,6 +688,109 @@ class GameStateTest {
                 () -> gameState.assignStartPosition("unknownPlayer"));
     }
 
+    // ── assignStartPosition(playerId, selectedPosition) – cheat feature ───
+
+    @Test
+    void testAssignStartPosition_withValidSelectedPosition() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        int pos = gameState.assignStartPosition(hostUser.id(), 42);
+
+        assertEquals(42, pos);
+        assertEquals(42, gameState.getPlayerPosition(hostUser.id()));
+    }
+
+    @Test
+    void testAssignStartPosition_selectedNull_fallsBackToRandom() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        int pos = gameState.assignStartPosition(hostUser.id(), null);
+
+        assertTrue(pos >= 1 && pos <= 199);
+        assertEquals(pos, gameState.getPlayerPosition(hostUser.id()));
+    }
+
+    @Test
+    void testAssignStartPosition_selectedBelowRange_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        String playerId = hostUser.id();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> gameState.assignStartPosition(playerId, 0));
+        assertTrue(ex.getMessage().contains("1 and 199"));
+    }
+
+    @Test
+    void testAssignStartPosition_selectedAboveRange_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        String playerId = hostUser.id();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> gameState.assignStartPosition(playerId, 200));
+        assertTrue(ex.getMessage().contains("1 and 199"));
+    }
+
+    @Test
+    void testAssignStartPosition_selectedNegative_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        String playerId = hostUser.id();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> gameState.assignStartPosition(playerId, -5));
+    }
+
+    @Test
+    void testAssignStartPosition_selectedAlreadyTaken_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        // first player takes position 50
+        gameState.assignStartPosition(hostUser.id(), 50);
+
+        // second player tries the same position
+        String secondId = detectiveUser1.id();
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> gameState.assignStartPosition(secondId, 50));
+        assertTrue(ex.getMessage().contains("already taken"));
+    }
+
+    @Test
+    void testAssignStartPosition_selectedPositionReturnsExistingIfAlreadyAssigned() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        // assign once
+        gameState.assignStartPosition(hostUser.id(), 77);
+
+        // calling again (even with a different selection) returns the already-assigned position
+        int pos = gameState.assignStartPosition(hostUser.id(), 33);
+
+        assertEquals(77, pos);
+    }
+
+    @Test
+    void testAssignStartPosition_unknownPlayerWithSelectedPosition_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> gameState.assignStartPosition("unknownPlayer", 42));
+    }
+
+    @Test
+    void testAssignStartPosition_twoDifferentSelectedPositions_areUnique() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        gameState.assignStartPosition(hostUser.id(), 10);
+        gameState.assignStartPosition(detectiveUser1.id(), 20);
+
+        assertEquals(10, gameState.getPlayerPosition(hostUser.id()));
+        assertEquals(20, gameState.getPlayerPosition(detectiveUser1.id()));
+    }
+
     // ── initializePlayersFromLobby ─────────────────────────────────────────
 
     @Test
@@ -730,5 +833,113 @@ class GameStateTest {
 
         int pos = gameState.assignStartPosition(hostUser.id());
         assertTrue(pos >= 1 && pos <= 199);
+    }
+
+    // ── confirmStartPosition ──────────────────────────────────────────────────
+
+    @Test
+    void testConfirmStartPosition_validPosition_setsAndReturnsIt() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        int pos = gameState.confirmStartPosition(hostUser.id(), 42);
+
+        assertEquals(42, pos);
+        assertEquals(42, gameState.getPlayerPosition(hostUser.id()));
+    }
+
+    @Test
+    void testConfirmStartPosition_belowRange_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        String pid = hostUser.id();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> gameState.confirmStartPosition(pid, 0));
+        assertTrue(ex.getMessage().contains("1 and 199"));
+    }
+
+    @Test
+    void testConfirmStartPosition_aboveRange_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        String pid = hostUser.id();
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> gameState.confirmStartPosition(pid, 200));
+        assertTrue(ex.getMessage().contains("1 and 199"));
+    }
+
+    @Test
+    void testConfirmStartPosition_negativeValue_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        String pid = hostUser.id();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> gameState.confirmStartPosition(pid, -1));
+    }
+
+    @Test
+    void testConfirmStartPosition_positionAlreadyTakenByOtherPlayer_throwsException() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        gameState.confirmStartPosition(hostUser.id(), 50);
+
+        String secondId = detectiveUser1.id();
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> gameState.confirmStartPosition(secondId, 50));
+        assertTrue(ex.getMessage().contains("already taken"));
+    }
+
+    @Test
+    void testConfirmStartPosition_samePlayerCanUpdatePosition() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        gameState.confirmStartPosition(hostUser.id(), 30);
+        int updated = gameState.confirmStartPosition(hostUser.id(), 80);
+
+        assertEquals(80, updated);
+        assertEquals(80, gameState.getPlayerPosition(hostUser.id()));
+    }
+
+    @Test
+    void testConfirmStartPosition_unknownPlayer_throwsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> gameState.confirmStartPosition("ghost", 42));
+    }
+
+    // ── allPlayersHaveStartPosition ───────────────────────────────────────────
+
+    @Test
+    void testAllPlayersHaveStartPosition_falseWhenNoneSet() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        assertFalse(gameState.allPlayersHaveStartPosition());
+    }
+
+    @Test
+    void testAllPlayersHaveStartPosition_falseWhenPartiallySet() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        gameState.confirmStartPosition(hostUser.id(), 10);
+        // detectiveUser1 not yet confirmed
+
+        assertFalse(gameState.allPlayersHaveStartPosition());
+    }
+
+    @Test
+    void testAllPlayersHaveStartPosition_trueWhenAllSet() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        gameState.confirmStartPosition(hostUser.id(), 10);
+        gameState.confirmStartPosition(detectiveUser1.id(), 20);
+
+        assertTrue(gameState.allPlayersHaveStartPosition());
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
@@ -881,16 +881,22 @@ class GameStateTest {
     }
 
     @Test
-    void testConfirmStartPosition_positionAlreadyTakenByOtherPlayer_throwsException() {
+    void testConfirmStartPosition_positionAlreadyTakenByOtherPlayer_assignsFreePosition() {
         setupBasicLobby();
         gameState.initializePlayersFromLobby(mockLobby);
 
         gameState.confirmStartPosition(hostUser.id(), 50);
 
+        // second player requests the same position – server must silently pick a free one
         String secondId = detectiveUser1.id();
-        IllegalStateException ex = assertThrows(IllegalStateException.class,
-                () -> gameState.confirmStartPosition(secondId, 50));
-        assertTrue(ex.getMessage().contains("already taken"));
+        int fallback = gameState.confirmStartPosition(secondId, 50);
+
+        // fallback must be valid and different from the taken position
+        assertTrue(fallback >= 1 && fallback <= 199);
+        assertNotEquals(50, fallback);
+        // both players must have distinct positions
+        assertNotEquals(gameState.getPlayerPosition(hostUser.id()),
+                gameState.getPlayerPosition(secondId));
     }
 
     @Test

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
@@ -942,4 +942,46 @@ class GameStateTest {
 
         assertTrue(gameState.allPlayersHaveStartPosition());
     }
+
+    @Test
+    void testAllPlayersHaveStartPosition_falseWhenGameHasNoPlayers() {
+        // fresh GameState with no players at all must return false
+        assertFalse(new GameState("empty-game").allPlayersHaveStartPosition());
+    }
+
+    // ── boundary values for assignStartPosition(playerId, selected) ──────────
+
+    @Test
+    void testAssignStartPosition_selectedBoundaryLow_valid() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        int pos = gameState.assignStartPosition(hostUser.id(), 1);
+        assertEquals(1, pos);
+    }
+
+    @Test
+    void testAssignStartPosition_selectedBoundaryHigh_valid() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        int pos = gameState.assignStartPosition(hostUser.id(), 199);
+        assertEquals(199, pos);
+    }
+
+    // ── boundary values for confirmStartPosition ──────────────────────────────
+
+    @Test
+    void testConfirmStartPosition_boundaryLow_valid() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        int pos = gameState.confirmStartPosition(hostUser.id(), 1);
+        assertEquals(1, pos);
+    }
+
+    @Test
+    void testConfirmStartPosition_boundaryHigh_valid() {
+        setupBasicLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        int pos = gameState.confirmStartPosition(hostUser.id(), 199);
+        assertEquals(199, pos);
+    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapperTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapperTest.java
@@ -149,21 +149,4 @@ class GameStateMapperTest {
         verify(mockGameState).getMrXRevealedPositions();
     }
 
-    @Test
-    void testToDto_isMrXPhase_false_whenDetectives() {
-        // setUp already configures DETECTIVES phase
-        assertFalse(GameStateMapper.toDto(mockGameState).isMrXPhase());
-    }
-
-    @Test
-    void testToDto_isDetectivesPhase_true_whenDetectives() {
-        assertTrue(GameStateMapper.toDto(mockGameState).isDetectivesPhase());
-    }
-
-    @Test
-    void testToDto_isMrXPhase_true_whenMrX() {
-        when(mockGameState.getCurrentPhase()).thenReturn(TurnType.MRX);
-        assertTrue(GameStateMapper.toDto(mockGameState).isMrXPhase());
-        assertFalse(GameStateMapper.toDto(mockGameState).isDetectivesPhase());
-    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapperTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapperTest.java
@@ -148,4 +148,22 @@ class GameStateMapperTest {
         verify(mockGameState).getMrXMoveHistory();
         verify(mockGameState).getMrXRevealedPositions();
     }
+
+    @Test
+    void testToDto_isMrXPhase_false_whenDetectives() {
+        // setUp already configures DETECTIVES phase
+        assertFalse(GameStateMapper.toDto(mockGameState).isMrXPhase());
+    }
+
+    @Test
+    void testToDto_isDetectivesPhase_true_whenDetectives() {
+        assertTrue(GameStateMapper.toDto(mockGameState).isDetectivesPhase());
+    }
+
+    @Test
+    void testToDto_isMrXPhase_true_whenMrX() {
+        when(mockGameState.getCurrentPhase()).thenReturn(TurnType.MRX);
+        assertTrue(GameStateMapper.toDto(mockGameState).isMrXPhase());
+        assertFalse(GameStateMapper.toDto(mockGameState).isDetectivesPhase());
+    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
@@ -1,5 +1,7 @@
 package at.aau.serg.websocketdemoserver.websocket.broker;
 
+import at.aau.serg.websocketdemoserver.dtos.game.GameStateDto;
+import at.aau.serg.websocketdemoserver.dtos.game.StartPositionConfirmRequest;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionRequest;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionResponse;
 import at.aau.serg.websocketdemoserver.dtos.StompMessage;
@@ -790,5 +792,290 @@ class WebSocketBrokerControllerTest {
         assertEquals(response.getStartPosition(), response2.getStartPosition());
 
         GameController.getInstance().removeGame("game-abc");
+    }
+
+    // ── handleStartPositionRequest – cheat/manual position ────────────────
+
+    private GameState buildGameWithPlayer(String gameId, String playerId) {
+        GameState gs = new GameState(gameId);
+        Lobby lobby = mock(Lobby.class);
+        User player = new User(playerId, "TestPlayer");
+        when(lobby.canStartGame()).thenReturn(true);
+        when(lobby.getUsers()).thenReturn(List.of(player));
+        when(lobby.getSelectedRole(playerId)).thenReturn(Role.DETECTIVE);
+        gs.initializePlayersFromLobby(lobby);
+        GameController.getInstance().addGame(gameId, gs);
+        return gs;
+    }
+
+    @Test
+    void testHandleStartPositionRequest_validSelectedPosition_usesIt() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("cheat-game-1", "player-cheat");
+
+        StartPositionRequest request = new StartPositionRequest("cheat-game-1", "player-cheat", 77);
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/cheat-game-1/player/player-cheat/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("START_POSITION_ASSIGNED", response.getType());
+        assertEquals(77, response.getStartPosition());
+
+        GameController.getInstance().removeGame("cheat-game-1");
+    }
+
+    @Test
+    void testHandleStartPositionRequest_selectedPositionBelowRange_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("cheat-game-2", "player-cheat");
+
+        StartPositionRequest request = new StartPositionRequest("cheat-game-2", "player-cheat", 0);
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/cheat-game-2/player/player-cheat/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertNull(response.getStartPosition());
+
+        GameController.getInstance().removeGame("cheat-game-2");
+    }
+
+    @Test
+    void testHandleStartPositionRequest_selectedPositionAboveRange_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("cheat-game-3", "player-cheat");
+
+        StartPositionRequest request = new StartPositionRequest("cheat-game-3", "player-cheat", 200);
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/cheat-game-3/player/player-cheat/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertNull(response.getStartPosition());
+
+        GameController.getInstance().removeGame("cheat-game-3");
+    }
+
+    @Test
+    void testHandleStartPositionRequest_selectedPositionAlreadyTaken_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        String gameId = "cheat-game-4";
+        GameState gs = new GameState(gameId);
+        Lobby lobby = mock(Lobby.class);
+        User p1 = new User("p1", "Player1");
+        User p2 = new User("p2", "Player2");
+        when(lobby.canStartGame()).thenReturn(true);
+        when(lobby.getUsers()).thenReturn(List.of(p1, p2));
+        when(lobby.getSelectedRole("p1")).thenReturn(Role.DETECTIVE);
+        when(lobby.getSelectedRole("p2")).thenReturn(Role.DETECTIVE);
+        gs.initializePlayersFromLobby(lobby);
+        GameController.getInstance().addGame(gameId, gs);
+
+        // p1 takes position 55
+        localController.handleStartPositionRequest(new StartPositionRequest(gameId, "p1", 55));
+
+        // p2 tries to take the same position
+        localController.handleStartPositionRequest(new StartPositionRequest(gameId, "p2", 55));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template, times(1)).convertAndSend(
+                eq("/topic/game/" + gameId + "/player/p2/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertNull(response.getStartPosition());
+
+        GameController.getInstance().removeGame(gameId);
+    }
+
+    @Test
+    void testHandleStartPositionRequest_noSelectedPosition_fallsBackToRandom() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("cheat-game-5", "player-auto");
+
+        // no selectedStartPosition field → backward-compat constructor
+        StartPositionRequest request = new StartPositionRequest("cheat-game-5", "player-auto");
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/cheat-game-5/player/player-auto/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("START_POSITION_ASSIGNED", response.getType());
+        assertNotNull(response.getStartPosition());
+        assertTrue(response.getStartPosition() >= 1 && response.getStartPosition() <= 199);
+
+        GameController.getInstance().removeGame("cheat-game-5");
+    }
+
+    // ── handleConfirmStartPosition ────────────────────────────────────────────
+
+    @Test
+    void testHandleConfirmStartPosition_validPosition_broadcastsGameState() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("conf-game-1", "player-conf");
+
+        StartPositionConfirmRequest req = new StartPositionConfirmRequest("conf-game-1", "player-conf", 55);
+        localController.handleConfirmStartPosition(req);
+
+        // GameStateDto must be sent to the movements topic
+        verify(template, atLeastOnce()).convertAndSend(
+                eq("/topic/game/conf-game-1/movements"),
+                any(GameStateDto.class)
+        );
+
+        // Player ack on player-specific topic
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/conf-game-1/player/player-conf/start-position"),
+                captor.capture()
+        );
+        StartPositionResponse ack = (StartPositionResponse) captor.getValue();
+        assertEquals("START_POSITION_CONFIRMED", ack.getType());
+        assertEquals(55, ack.getStartPosition());
+
+        GameController.getInstance().removeGame("conf-game-1");
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_positionBelowRange_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("conf-game-2", "pc2");
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("conf-game-2", "pc2", 0));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/conf-game-2/player/pc2/start-position"),
+                captor.capture()
+        );
+        StartPositionResponse resp = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", resp.getType());
+
+        GameController.getInstance().removeGame("conf-game-2");
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_positionAboveRange_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        buildGameWithPlayer("conf-game-3", "pc3");
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("conf-game-3", "pc3", 200));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/conf-game-3/player/pc3/start-position"),
+                captor.capture()
+        );
+        StartPositionResponse resp = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", resp.getType());
+
+        GameController.getInstance().removeGame("conf-game-3");
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_gameNotFound_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        localController.handleConfirmStartPosition(
+                new StartPositionConfirmRequest("no-such-game", "player-x", 42));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/no-such-game/player/player-x/start-position"),
+                captor.capture()
+        );
+        StartPositionResponse resp = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", resp.getType());
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_positionAlreadyTaken_returnsError() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        String gameId = "conf-game-4";
+        GameState gs = new GameState(gameId);
+        Lobby lobby = mock(Lobby.class);
+        User p1 = new User("cp1", "Conf1");
+        User p2 = new User("cp2", "Conf2");
+        when(lobby.canStartGame()).thenReturn(true);
+        when(lobby.getUsers()).thenReturn(List.of(p1, p2));
+        when(lobby.getSelectedRole("cp1")).thenReturn(Role.DETECTIVE);
+        when(lobby.getSelectedRole("cp2")).thenReturn(Role.DETECTIVE);
+        gs.initializePlayersFromLobby(lobby);
+        GameController.getInstance().addGame(gameId, gs);
+
+        // first player takes position 66
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest(gameId, "cp1", 66));
+
+        // second player tries the same position
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest(gameId, "cp2", 66));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template, times(1)).convertAndSend(
+                eq("/topic/game/" + gameId + "/player/cp2/start-position"),
+                captor.capture()
+        );
+        StartPositionResponse resp = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", resp.getType());
+
+        GameController.getInstance().removeGame(gameId);
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_allPlayersConfirmed_broadcastsGameStateTwice() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        // Build a game with a single player so "all confirmed" triggers after one confirm
+        buildGameWithPlayer("conf-game-5", "solo");
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("conf-game-5", "solo", 77));
+
+        // broadcastGameState called twice: once after set, once for "all ready"
+        verify(template, times(2)).convertAndSend(
+                eq("/topic/game/conf-game-5/movements"),
+                any(GameStateDto.class)
+        );
+
+        GameController.getInstance().removeGame("conf-game-5");
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
@@ -781,6 +781,12 @@ class WebSocketBrokerControllerTest {
         assertNotNull(response.getStartPosition());
         assertTrue(response.getStartPosition() >= 1 && response.getStartPosition() <= 199);
 
+        // GameState must be broadcast so board renders the figure
+        verify(template).convertAndSend(
+                eq("/topic/game/game-abc/movements"),
+                any(GameStateDto.class)
+        );
+
         // calling again returns the same position
         localController.handleStartPositionRequest(request);
         ArgumentCaptor<Object> captor2 = ArgumentCaptor.forClass(Object.class);
@@ -790,6 +796,12 @@ class WebSocketBrokerControllerTest {
         );
         StartPositionResponse response2 = (StartPositionResponse) captor2.getAllValues().get(1);
         assertEquals(response.getStartPosition(), response2.getStartPosition());
+
+        // Two successful calls → two broadcasts
+        verify(template, times(2)).convertAndSend(
+                eq("/topic/game/game-abc/movements"),
+                any(GameStateDto.class)
+        );
 
         GameController.getInstance().removeGame("game-abc");
     }
@@ -827,6 +839,12 @@ class WebSocketBrokerControllerTest {
         StartPositionResponse response = (StartPositionResponse) captor.getValue();
         assertEquals("START_POSITION_ASSIGNED", response.getType());
         assertEquals(77, response.getStartPosition());
+
+        // The updated GameState must also be broadcast so the board renders the new figure
+        verify(template).convertAndSend(
+                eq("/topic/game/cheat-game-1/movements"),
+                any(GameStateDto.class)
+        );
 
         GameController.getInstance().removeGame("cheat-game-1");
     }
@@ -896,6 +914,11 @@ class WebSocketBrokerControllerTest {
 
         // p1 takes position 55
         localController.handleStartPositionRequest(new StartPositionRequest(gameId, "p1", 55));
+        // p1 success → one broadcast to movements
+        verify(template, times(1)).convertAndSend(
+                eq("/topic/game/" + gameId + "/movements"),
+                any(GameStateDto.class)
+        );
 
         // p2 tries to take the same position
         localController.handleStartPositionRequest(new StartPositionRequest(gameId, "p2", 55));
@@ -934,6 +957,12 @@ class WebSocketBrokerControllerTest {
         assertEquals("START_POSITION_ASSIGNED", response.getType());
         assertNotNull(response.getStartPosition());
         assertTrue(response.getStartPosition() >= 1 && response.getStartPosition() <= 199);
+
+        // GameState broadcast must also happen on random-fallback path
+        verify(template).convertAndSend(
+                eq("/topic/game/cheat-game-5/movements"),
+                any(GameStateDto.class)
+        );
 
         GameController.getInstance().removeGame("cheat-game-5");
     }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
@@ -1189,4 +1189,67 @@ class WebSocketBrokerControllerTest {
 
         GameController.getInstance().removeGame("conf-game-5");
     }
+
+    // ── handleConfirmStartPosition – null / blank input guards ───────────────
+
+    @Test
+    void testHandleConfirmStartPosition_nullRequest_doesNotThrow() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        assertDoesNotThrow(() -> localController.handleConfirmStartPosition(null));
+        verifyNoInteractions(template);
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_nullGameId_sendsErrorToGenericTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest(null, "player-x", 42));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(eq("/topic/game/error"), captor.capture());
+        assertEquals("ERROR", ((StartPositionResponse) captor.getValue()).getType());
+        assertEquals("gameId must not be blank", ((StartPositionResponse) captor.getValue()).getMessage());
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_blankGameId_sendsErrorToGenericTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("  ", "player-x", 42));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(eq("/topic/game/error"), captor.capture());
+        assertEquals("ERROR", ((StartPositionResponse) captor.getValue()).getType());
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_nullPlayerId_sendsErrorToGameTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("some-game", null, 42));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/some-game/player/unknown/start-position"), captor.capture());
+        assertEquals("ERROR", ((StartPositionResponse) captor.getValue()).getType());
+        assertEquals("playerId must not be blank", ((StartPositionResponse) captor.getValue()).getMessage());
+    }
+
+    @Test
+    void testHandleConfirmStartPosition_blankPlayerId_sendsErrorToGameTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("some-game", "", 42));
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/some-game/player/unknown/start-position"), captor.capture());
+        assertEquals("ERROR", ((StartPositionResponse) captor.getValue()).getType());
+    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
@@ -967,6 +967,88 @@ class WebSocketBrokerControllerTest {
         GameController.getInstance().removeGame("cheat-game-5");
     }
 
+    // ── handleStartPositionRequest – null / blank input guards ───────────────
+
+    @Test
+    void testHandleStartPositionRequest_nullRequest_doesNotThrow() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        assertDoesNotThrow(() -> localController.handleStartPositionRequest(null));
+        // nothing should be sent – no recipient address available
+        verifyNoInteractions(template);
+    }
+
+    @Test
+    void testHandleStartPositionRequest_nullGameId_sendsErrorToGenericTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        StartPositionRequest request = new StartPositionRequest(null, "player-1");
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(eq("/topic/game/error"), captor.capture());
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertEquals("gameId must not be blank", response.getMessage());
+    }
+
+    @Test
+    void testHandleStartPositionRequest_blankGameId_sendsErrorToGenericTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        StartPositionRequest request = new StartPositionRequest("  ", "player-1");
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(eq("/topic/game/error"), captor.capture());
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertEquals("gameId must not be blank", response.getMessage());
+    }
+
+    @Test
+    void testHandleStartPositionRequest_nullPlayerId_sendsErrorToGameTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        StartPositionRequest request = new StartPositionRequest("some-game", null);
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/some-game/player/unknown/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertEquals("playerId must not be blank", response.getMessage());
+    }
+
+    @Test
+    void testHandleStartPositionRequest_blankPlayerId_sendsErrorToGameTopic() {
+        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
+        WebSocketBrokerController localController = controllerWithMockTemplate(template);
+
+        StartPositionRequest request = new StartPositionRequest("some-game", "");
+        localController.handleStartPositionRequest(request);
+
+        ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+        verify(template).convertAndSend(
+                eq("/topic/game/some-game/player/unknown/start-position"),
+                captor.capture()
+        );
+
+        StartPositionResponse response = (StartPositionResponse) captor.getValue();
+        assertEquals("ERROR", response.getType());
+        assertEquals("playerId must not be blank", response.getMessage());
+    }
+
     // ── handleConfirmStartPosition ────────────────────────────────────────────
 
     @Test

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
@@ -1052,7 +1052,7 @@ class WebSocketBrokerControllerTest {
     // ── handleConfirmStartPosition ────────────────────────────────────────────
 
     @Test
-    void testHandleConfirmStartPosition_validPosition_broadcastsGameState() {
+    void testHandleConfirmStartPosition_validPosition_sendsAckToPlayerTopic() {
         SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
         WebSocketBrokerController localController = controllerWithMockTemplate(template);
 
@@ -1061,13 +1061,7 @@ class WebSocketBrokerControllerTest {
         StartPositionConfirmRequest req = new StartPositionConfirmRequest("conf-game-1", "player-conf", 55);
         localController.handleConfirmStartPosition(req);
 
-        // GameStateDto must be sent to the movements topic
-        verify(template, atLeastOnce()).convertAndSend(
-                eq("/topic/game/conf-game-1/movements"),
-                any(GameStateDto.class)
-        );
-
-        // Player ack on player-specific topic
+        // ONLY the player-specific topic must receive the ack – no board-state broadcast
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
         verify(template).convertAndSend(
                 eq("/topic/game/conf-game-1/player/player-conf/start-position"),
@@ -1076,6 +1070,12 @@ class WebSocketBrokerControllerTest {
         StartPositionResponse ack = (StartPositionResponse) captor.getValue();
         assertEquals("START_POSITION_CONFIRMED", ack.getType());
         assertEquals(55, ack.getStartPosition());
+
+        // Must NOT broadcast GameStateDto to the movements topic
+        verify(template, never()).convertAndSend(
+                eq("/topic/game/conf-game-1/movements"),
+                any(GameStateDto.class)
+        );
 
         GameController.getInstance().removeGame("conf-game-1");
     }
@@ -1138,7 +1138,7 @@ class WebSocketBrokerControllerTest {
     }
 
     @Test
-    void testHandleConfirmStartPosition_positionAlreadyTaken_returnsError() {
+    void testHandleConfirmStartPosition_positionAlreadyTaken_assignsFallbackPosition() {
         SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
         WebSocketBrokerController localController = controllerWithMockTemplate(template);
 
@@ -1157,7 +1157,7 @@ class WebSocketBrokerControllerTest {
         // first player takes position 66
         localController.handleConfirmStartPosition(new StartPositionConfirmRequest(gameId, "cp1", 66));
 
-        // second player tries the same position
+        // second player requests the same position → server assigns a free fallback
         localController.handleConfirmStartPosition(new StartPositionConfirmRequest(gameId, "cp2", 66));
 
         ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
@@ -1166,29 +1166,14 @@ class WebSocketBrokerControllerTest {
                 captor.capture()
         );
         StartPositionResponse resp = (StartPositionResponse) captor.getValue();
-        assertEquals("ERROR", resp.getType());
+        assertEquals("START_POSITION_CONFIRMED", resp.getType());
+        assertNotNull(resp.getStartPosition());
+        assertNotEquals(66, resp.getStartPosition());
+        assertTrue(resp.getStartPosition() >= 1 && resp.getStartPosition() <= 199);
 
         GameController.getInstance().removeGame(gameId);
     }
 
-    @Test
-    void testHandleConfirmStartPosition_allPlayersConfirmed_broadcastsGameStateTwice() {
-        SimpMessagingTemplate template = mock(SimpMessagingTemplate.class);
-        WebSocketBrokerController localController = controllerWithMockTemplate(template);
-
-        // Build a game with a single player so "all confirmed" triggers after one confirm
-        buildGameWithPlayer("conf-game-5", "solo");
-
-        localController.handleConfirmStartPosition(new StartPositionConfirmRequest("conf-game-5", "solo", 77));
-
-        // broadcastGameState called twice: once after set, once for "all ready"
-        verify(template, times(2)).convertAndSend(
-                eq("/topic/game/conf-game-5/movements"),
-                any(GameStateDto.class)
-        );
-
-        GameController.getInstance().removeGame("conf-game-5");
-    }
 
     // ── handleConfirmStartPosition – null / blank input guards ───────────────
 


### PR DESCRIPTION
This PR adds backend support for cheat/debug start position selection and confirmation.

Changes:
Added support for manually selected start positions in StartPositionRequest
Added StartPositionConfirmRequest for confirming a chosen start position
Extended GameState with validation and confirmation logic for start positions
Added checks for valid range and already occupied positions
Updated the WebSocket controller to handle start position confirmation and broadcast updated game state
Extended GameStateDto with phase convenience flags (isMrXPhase, isDetectivesPhase)
Added/updated tests for DTOs, game state logic, mapper behavior, and WebSocket handling