### PR TITLE
fix: prevent premature MrX win, block moves until all players ready, add stuck-detective locking

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
@@ -23,4 +23,5 @@ public class GameStateDto {
     private Map<String, Integer> mrXSpecialTickets;             // only BLACK and DOUBLE
     private List<String> mrXMoveHistory;
     private Map<Integer, Integer> mrXRevealedPositions;
+    private boolean allPlayersReady;
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
@@ -327,6 +327,9 @@ public class GameState {
 
     public boolean movePlayer(String playerId, TicketType ticket, int newPosition) {
         try {
+            if (!allPlayersHaveStartPosition()) {   // block moves until everyone is on the board
+                return false;
+            }
             if (!players.containsKey(playerId)) {   // player has to exist to move
                 return false;
             }
@@ -373,11 +376,34 @@ public class GameState {
         return getDetectivePositions().containsValue(mrXPos);
     }
 
+    public boolean hasValidMoves(String detectiveId) {
+        Integer pos = playerPositions.get(detectiveId);
+        if (pos == null) return true;   // no position yet = not placed, not stuck
+        Player p = players.get(detectiveId);
+        if (p == null) return false;
+        return board.getStation(pos).getConnections().stream()
+                .anyMatch(c -> p.hasTicket(c.transport()));
+    }
+
+    // Locks all pending detectives with no valid moves. Call this after each move
+    // so that stuck detectives are never waited on again.
+    public void lockStuckDetectives() {
+        if (!roundController.isDetectiveTurn()) return;
+        for (String id : new HashSet<>(roundController.getPendingDetectives())) {
+            if (!hasValidMoves(id)) {
+                roundController.lockDetective(id);
+            }
+        }
+    }
+
     public GameResult checkGameResult() {
         if (isCaught()) {
             return GameResult.DETECTIVES_WIN;
         }
         if (getCurrentRound() > MAX_ROUNDS) {
+            return GameResult.MRX_WINS;
+        }
+        if (roundController.allDetectivesLocked()) {
             return GameResult.MRX_WINS;
         }
         return GameResult.ONGOING;

--- a/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
@@ -19,7 +19,8 @@ public class GameStateMapper {
                 gameState.getPlayerTickets(),
                 gameState.getMrXSpecialTickets(),
                 gameState.getMrXMoveHistory(),
-                gameState.getMrXRevealedPositions()
+                gameState.getMrXRevealedPositions(),
+                gameState.allPlayersHaveStartPosition()
         );
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/RoundController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/RoundController.java
@@ -36,6 +36,7 @@ public class RoundController {
 
     private final Set<String> pendingDetectives = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
+    @Getter
     private final Set<String> allDetectiveIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private final Set<String> lockedDetectives = Collections.newSetFromMap(new ConcurrentHashMap<>());

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/RoundController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/RoundController.java
@@ -38,9 +38,22 @@ public class RoundController {
 
     private final Set<String> allDetectiveIds = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
+    private final Set<String> lockedDetectives = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
     public void initDetectives(Set<String> detectiveIds) {
         allDetectiveIds.clear();
         allDetectiveIds.addAll(detectiveIds);
+        lockedDetectives.clear();
+    }
+
+    public synchronized void lockDetective(String detectiveId) {
+        lockedDetectives.add(detectiveId);
+        allDetectiveIds.remove(detectiveId);
+        pendingDetectives.remove(detectiveId);
+    }
+
+    public boolean allDetectivesLocked() {
+        return !lockedDetectives.isEmpty() && allDetectiveIds.isEmpty();
     }
 
     public synchronized void activateDoubleMove() {

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -475,6 +475,8 @@ public class WebSocketBrokerController {
 
             log.debug("Move executed successfully, new position={}", gameState.getPlayerPosition(movement.getPlayerId()));
 
+            gameState.lockStuckDetectives();
+
             switch (gameState.checkGameResult()) {
                 case DETECTIVES_WIN -> {
                     broadcastGameState(gameId, gameState);

--- a/src/test/java/at/aau/serg/websocketdemoserver/WebSocketBrokerIntegrationTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/WebSocketBrokerIntegrationTest.java
@@ -112,6 +112,8 @@ class WebSocketBrokerIntegrationTest {
 
         GameState gameState = gameController.getGame(gameId);
         gameState.setPlayerPosition(playerId, 1);
+        gameState.setPlayerPosition("user2", 50);
+        gameState.setPlayerPosition("user3", 100);
         gameState.getRoundController().setCurrentPhase(TurnType.DETECTIVES);
         gameState.getRoundController().addPendingDetectives(playerId);
 
@@ -191,6 +193,7 @@ class WebSocketBrokerIntegrationTest {
         GameState gameState = gameController.getGame(gameId);
         // Beide Detektive auf Startposition 1 setzen, Ziel 8 ist von 1 aus gültig.
         gameState.setPlayerPosition(playerId, 1);
+        gameState.setPlayerPosition("user2", 50);
         gameState.setPlayerPosition("user3", 1);
         gameState.getRoundController().setCurrentPhase(TurnType.DETECTIVES);
         gameState.getRoundController().addPendingDetectives(playerId);
@@ -374,6 +377,8 @@ class WebSocketBrokerIntegrationTest {
 
         GameState gameState = gameController.getGame(gameId);
         gameState.setPlayerPosition("user2", 2);
+        gameState.setPlayerPosition(playerId, 1);
+        gameState.setPlayerPosition("user3", 50);
 
         session.send("/app/game/" + gameId + "/move",
                 createMovementMessage(gameId, "user2", TicketType.DOUBLE, 20));
@@ -402,6 +407,7 @@ class WebSocketBrokerIntegrationTest {
         GameState gameState = gameController.getGame(gameId);
         gameState.setPlayerPosition("user2", 2);
         gameState.setPlayerPosition(playerId, 1);
+        gameState.setPlayerPosition("user3", 50);
         gameState.getRoundController().activateDoubleMove();
         gameState.movePlayer("user2", TicketType.WALKING, 20);
         gameState.movePlayer("user2", TicketType.WALKING, 2);
@@ -439,6 +445,7 @@ class WebSocketBrokerIntegrationTest {
         GameState gameState = gameController.getGame(gameId);
         gameState.setPlayerPosition("user2", 20);
         gameState.setPlayerPosition(playerId, 2);
+        gameState.setPlayerPosition("user3", 50);
         gameState.getRoundController().setCurrentPhase(TurnType.DETECTIVES);
         gameState.getRoundController().addPendingDetectives(playerId);
 
@@ -457,6 +464,7 @@ class WebSocketBrokerIntegrationTest {
         GameState gameState = gameController.getGame(gameId);
         gameState.setPlayerPosition("user2", 20);
         gameState.setPlayerPosition(playerId, 2);
+        gameState.setPlayerPosition("user3", 50);
         gameState.getRoundController().setCurrentPhase(TurnType.DETECTIVES);
         gameState.getRoundController().addPendingDetectives(playerId);
 
@@ -522,6 +530,7 @@ class WebSocketBrokerIntegrationTest {
         }
         gameState.setPlayerPosition("user2", 20);
         gameState.setPlayerPosition(playerId, 2);
+        gameState.setPlayerPosition("user3", 50);
         gameState.getRoundController().setCurrentPhase(TurnType.DETECTIVES);
         gameState.getRoundController().addPendingDetectives(playerId);
 

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
@@ -22,7 +22,8 @@ class GameStateDtoTest {
                 Map.of("det1", Map.of("WALKING", 10)),
                 Map.of("BLACK", 5, "DOUBLE", 2),
                 List.of("WALKING", "ESCOOTER"),
-                Map.of(3, 42)
+                Map.of(3, 42),
+                true
         );
     }
 
@@ -84,7 +85,26 @@ class GameStateDtoTest {
     @Test
     void testNullMrXPosition() {
         GameStateDto dto = new GameStateDto("g1", 1, TurnType.MRX,
-                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of());
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false);
         assertThat(dto.getMrXPosition()).isNull();
+    }
+
+    @Test
+    void testAllPlayersReady_trueAndFalse() {
+        GameStateDto ready = buildDto("g1", 1, TurnType.MRX);
+        assertThat(ready.isAllPlayersReady()).isTrue();
+
+        GameStateDto notReady = new GameStateDto("g1", 1, TurnType.MRX,
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false);
+        assertThat(notReady.isAllPlayersReady()).isFalse();
+    }
+
+    @Test
+    void testSetAllPlayersReady() {
+        GameStateDto dto = buildDto("g1", 1, TurnType.MRX);
+        dto.setAllPlayersReady(false);
+        assertThat(dto.isAllPlayersReady()).isFalse();
+        dto.setAllPlayersReady(true);
+        assertThat(dto.isAllPlayersReady()).isTrue();
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
@@ -341,6 +341,7 @@ class GameStateTest {
 
         // set to a known position with connections
         gameState.setPlayerPosition(hostUser.id(), 2);
+        gameState.setPlayerPosition(detectiveUser1.id(), 100);
 
         // get ticket count before move
         int ticketCountBefore = gameState.getPlayer(hostUser.id()).getTickets().get(TicketType.WALKING);
@@ -481,6 +482,7 @@ class GameStateTest {
         gameState.initializePlayersFromLobby(mockLobby);
 
         gameState.setPlayerPosition(hostUser.id(), 77);
+        gameState.setPlayerPosition(detectiveUser1.id(), 100);
 
         // set TurnType to DETECTIVES
         gameState.getRoundController().setCurrentPhase(TurnType.DETECTIVES);

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateTest.java
@@ -990,4 +990,131 @@ class GameStateTest {
         int pos = gameState.confirmStartPosition(hostUser.id(), 199);
         assertEquals(199, pos);
     }
+
+    // hasValidMoves
+
+    @Test
+    void testHasValidMoves_nullPosition_returnsTrue() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        // detectiveUser1 has no position assigned yet
+        assertTrue(gameState.hasValidMoves(detectiveUser1.id()));
+    }
+
+    @Test
+    void testHasValidMoves_unknownPlayer_returnsTrue() {
+        // unknown player → no position → returns true (safe default)
+        assertTrue(gameState.hasValidMoves("nonexistent"));
+    }
+
+    @Test
+    void testHasValidMoves_withFullTickets_returnsTrue() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        gameState.setPlayerPosition(detectiveUser1.id(), 77); // has WALKING/ESCOOTER/CARSHARING connections
+        assertTrue(gameState.hasValidMoves(detectiveUser1.id()));
+    }
+
+    @Test
+    void testHasValidMoves_noTickets_returnsFalse() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        gameState.setPlayerPosition(detectiveUser1.id(), 77);
+
+        // drain all detective tickets
+        var detective = gameState.getPlayer(detectiveUser1.id());
+        for (int i = 0; i < 10; i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.WALKING);
+        for (int i = 0; i < 8;  i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.ESCOOTER);
+        for (int i = 0; i < 4;  i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.CARSHARING);
+
+        assertFalse(gameState.hasValidMoves(detectiveUser1.id()));
+    }
+
+    // lockStuckDetectives
+
+    @Test
+    void testLockStuckDetectives_noopDuringMrXPhase() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        gameState.setPlayerPosition(detectiveUser1.id(), 77);
+
+        var detective = gameState.getPlayer(detectiveUser1.id());
+        for (int i = 0; i < 10; i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.WALKING);
+        for (int i = 0; i < 8;  i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.ESCOOTER);
+        for (int i = 0; i < 4;  i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.CARSHARING);
+
+        // phase is MRX by default — lockStuckDetectives should do nothing
+        gameState.lockStuckDetectives();
+        assertFalse(gameState.getRoundController().allDetectivesLocked());
+    }
+
+    @Test
+    void testLockStuckDetectives_locksDetectiveWithNoMoves() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        gameState.setPlayerPosition(mrXUser.id(), 1);
+        gameState.setPlayerPosition(hostUser.id(), 77);
+        gameState.setPlayerPosition(detectiveUser1.id(), 77);
+
+        // drain detectiveUser1 tickets
+        var detective = gameState.getPlayer(detectiveUser1.id());
+        for (int i = 0; i < 10; i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.WALKING);
+        for (int i = 0; i < 8;  i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.ESCOOTER);
+        for (int i = 0; i < 4;  i++) detective.useTicket(at.aau.serg.websocketdemoserver.gamelogic.player.TicketType.CARSHARING);
+
+        // switch to detective phase with detectiveUser1 pending
+        gameState.getRoundController().setCurrentPhase(at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType.DETECTIVES);
+        gameState.getRoundController().addPendingDetectives(detectiveUser1.id());
+
+        gameState.lockStuckDetectives();
+
+        assertFalse(gameState.getRoundController().getPendingDetectives().contains(detectiveUser1.id()));
+    }
+
+    @Test
+    void testLockStuckDetectives_doesNotLockDetectiveWithMoves() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        gameState.setPlayerPosition(detectiveUser1.id(), 77);
+
+        gameState.getRoundController().setCurrentPhase(at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType.DETECTIVES);
+        gameState.getRoundController().addPendingDetectives(detectiveUser1.id());
+
+        gameState.lockStuckDetectives();
+
+        // still has tickets → not locked
+        assertFalse(gameState.getRoundController().allDetectivesLocked());
+        assertTrue(gameState.getRoundController().getPendingDetectives().contains(detectiveUser1.id()));
+    }
+
+    // checkGameResult with allDetectivesLocked
+
+    @Test
+    void testCheckGameResult_allDetectivesLocked_mrxWins() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+        gameState.setPlayerPosition(mrXUser.id(), 1);
+        gameState.setPlayerPosition(hostUser.id(), 77);
+        gameState.setPlayerPosition(detectiveUser1.id(), 77);
+
+        // lock all detectives manually
+        gameState.getRoundController().lockDetective(hostUser.id());
+        gameState.getRoundController().lockDetective(detectiveUser1.id());
+
+        assertEquals(GameResult.MRX_WINS, gameState.checkGameResult());
+    }
+
+    // movePlayer blocked when not all positions set
+
+    @Test
+    void testMovePlayer_blockedWhenNotAllPlayersHavePositions() {
+        setupBasicMrxLobby();
+        gameState.initializePlayersFromLobby(mockLobby);
+
+        // only MrX has a position, detectives don't
+        gameState.setPlayerPosition(mrXUser.id(), 13);
+
+        boolean result = gameState.movePlayer(mrXUser.id(), TicketType.WALKING, 14);
+        assertFalse(result);
+    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapperTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapperTest.java
@@ -35,6 +35,7 @@ class GameStateMapperTest {
         when(mockGameState.getMrXSpecialTickets()).thenReturn(Map.of("BLACK", 4, "DOUBLE", 2));
         when(mockGameState.getMrXMoveHistory()).thenReturn(List.of("WALKING", "ESCOOTER"));
         when(mockGameState.getMrXRevealedPositions()).thenReturn(Map.of(3, 99));
+        when(mockGameState.allPlayersHaveStartPosition()).thenReturn(true);
     }
 
     @Test
@@ -147,6 +148,19 @@ class GameStateMapperTest {
         verify(mockGameState).getMrXSpecialTickets();
         verify(mockGameState).getMrXMoveHistory();
         verify(mockGameState).getMrXRevealedPositions();
+        verify(mockGameState).allPlayersHaveStartPosition();
+    }
+
+    @Test
+    void testToDto_allPlayersReady_true() {
+        when(mockGameState.allPlayersHaveStartPosition()).thenReturn(true);
+        assertTrue(GameStateMapper.toDto(mockGameState).isAllPlayersReady());
+    }
+
+    @Test
+    void testToDto_allPlayersReady_false() {
+        when(mockGameState.allPlayersHaveStartPosition()).thenReturn(false);
+        assertFalse(GameStateMapper.toDto(mockGameState).isAllPlayersReady());
     }
 
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/service/RoundControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/service/RoundControllerTest.java
@@ -408,4 +408,68 @@ class RoundControllerTest {
         assertTrue(roundController.isDetectiveTurn());
         assertFalse(roundController.isMrXTurn());
     }
+
+    // lockDetective / allDetectivesLocked
+
+    @Test
+    void testLockDetective_removesFromActiveAndPending() {
+        roundController.initDetectives(Set.of("d1", "d2"));
+        roundController.recordMrXMove(); // puts both in pending
+        roundController.lockDetective("d1");
+
+        assertFalse(roundController.getPendingDetectives().contains("d1"));
+        assertFalse(roundController.getAllDetectiveIds().contains("d1"));
+    }
+
+    @Test
+    void testLockDetective_doesNotAffectOtherDetective() {
+        roundController.initDetectives(Set.of("d1", "d2"));
+        roundController.recordMrXMove();
+        roundController.lockDetective("d1");
+
+        assertTrue(roundController.getPendingDetectives().contains("d2"));
+        assertTrue(roundController.getAllDetectiveIds().contains("d2"));
+    }
+
+    @Test
+    void testAllDetectivesLocked_falseWhenNoneRegistered() {
+        assertFalse(roundController.allDetectivesLocked());
+    }
+
+    @Test
+    void testAllDetectivesLocked_falseWhenSomeStillActive() {
+        roundController.initDetectives(Set.of("d1", "d2"));
+        roundController.lockDetective("d1");
+
+        assertFalse(roundController.allDetectivesLocked());
+    }
+
+    @Test
+    void testAllDetectivesLocked_trueWhenAllLocked() {
+        roundController.initDetectives(Set.of("d1", "d2"));
+        roundController.lockDetective("d1");
+        roundController.lockDetective("d2");
+
+        assertTrue(roundController.allDetectivesLocked());
+    }
+
+    @Test
+    void testInitDetectives_clearsLockedSet() {
+        roundController.initDetectives(Set.of("d1"));
+        roundController.lockDetective("d1");
+        assertTrue(roundController.allDetectivesLocked());
+
+        roundController.initDetectives(Set.of("d1"));
+        assertFalse(roundController.allDetectivesLocked());
+    }
+
+    @Test
+    void testLockedDetective_notAddedToPendingOnNextMrXMove() {
+        roundController.initDetectives(Set.of("d1", "d2"));
+        roundController.lockDetective("d1");
+        roundController.recordMrXMove();
+
+        assertFalse(roundController.getPendingDetectives().contains("d1"));
+        assertTrue(roundController.getPendingDetectives().contains("d2"));
+    }
 }


### PR DESCRIPTION
- Fixed a race condition where MrX could trigger an instant win by moving before all
  detectives had confirmed their start position. Detectives without a position yet had
  no entry in playerPositions, causing hasValidMoves() to return false, locking them
  immediately and triggering allDetectivesLocked() → MRX_WINS. Fix: movePlayer() now
  returns false (blocks the move) until allPlayersHaveStartPosition() is true. As an
  additional safety net, hasValidMoves() returns true for detectives with no position
  yet

- Added MrX win condition for stuck detectives: if a detective has no valid moves
  (every connection from their current station requires a ticket type they have run
  out of), they are permanently locked via lockDetective() in RoundController and
  removed from allDetectiveIds. If ALL detectives end up locked, checkGameResult()
  returns MRX_WINS. Locking runs automatically after every move via
  lockStuckDetectives() in GameState, which is called in WebSocketBrokerController
  before checkGameResult().

- Added allPlayersReady boolean to GameStateDto (mapped from
  GameState.allPlayersHaveStartPosition()) so the client can show a waiting banner
  and suppress isMyTurn until the game is actually ready to start.