### PR TITLE
setup/docker resource limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 services:
   server:
+    container_name: scotland-yard
     image: ghcr.io/se2-s26-gruppe2-scotlandyard/scotlandyard-server:latest
+    pull_policy: always
     restart: unless-stopped
     ports:
       - "53206:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 1g
+        reservations:
+          cpus: "0.5"
+          memory: 512m


### PR DESCRIPTION
## Docker Resource Limits

Adds CPU and memory limits to the `docker-compose.yml` to ensure the container does not overconsume shared server resources on `se2-demo.aau.at`.

### Changes
- `docker-compose.yml`: Added `deploy.resources` with limits and reservations

### Resource Configuration
| | CPU | Memory |
|---|---|---|
| **Limit** | 1 core | 1 GB |
| **Reservation** | 0.5 cores | 512 MB |