### PR TITLE
 Game State Recovery + Host Kick Endpoints

### DIFF
--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
@@ -26,4 +26,5 @@ public class GameStateDto {
     private Map<Integer, Integer> mrXRevealedPositions;
     private boolean allPlayersReady;
     private Map<String, String> playerNames;
+    private java.util.Set<String> disconnectedPlayers;
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDto.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public class GameStateDto {
     private String gameId;
     private int currentRound;
+    private String hostId;
     private TurnType currentPhase;
     private Map<String, Integer> detectivePositions;
     private Integer mrXPosition;
@@ -24,4 +25,5 @@ public class GameStateDto {
     private List<String> mrXMoveHistory;
     private Map<Integer, Integer> mrXRevealedPositions;
     private boolean allPlayersReady;
+    private Map<String, String> playerNames;
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/KickPlayerInGameMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/KickPlayerInGameMessage.java
@@ -1,0 +1,16 @@
+package at.aau.serg.websocketdemoserver.dtos.game;
+
+public class KickPlayerInGameMessage {
+    private String gameId;
+    private String requesterId;
+    private String targetId;
+
+    public KickPlayerInGameMessage() {}
+
+    public String getGameId() { return gameId; }
+    public void setGameId(String gameId) { this.gameId = gameId; }
+    public String getRequesterId() { return requesterId; }
+    public void setRequesterId(String requesterId) { this.requesterId = requesterId; }
+    public String getTargetId() { return targetId; }
+    public void setTargetId(String targetId) { this.targetId = targetId; }
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/RejoinGameMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/game/RejoinGameMessage.java
@@ -1,0 +1,13 @@
+package at.aau.serg.websocketdemoserver.dtos.game;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RejoinGameMessage {
+    private String gameId;
+    private String userId;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/dtos/lobby/RejoinLobbyMessage.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/dtos/lobby/RejoinLobbyMessage.java
@@ -1,0 +1,14 @@
+package at.aau.serg.websocketdemoserver.dtos.lobby;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RejoinLobbyMessage {
+    private String lobbyId;
+    private String userId;
+    private String nickName;
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/gamelogic/GameState.java
@@ -26,6 +26,8 @@ public class GameState {
     private final Map<String, Player> players = new HashMap<>();
     protected Map<String, Integer> playerPositions = new HashMap<>();
     private String mrXId;
+    @Getter
+    private String hostId;
     public static final int MAX_ROUNDS = 22;
     private final Random RANDOM = new Random();     //NOSONAR not used in secure contexts
     private final List<TicketType> mrXMoveHistory = new ArrayList<>(MAX_ROUNDS + 2);    // 2 = MAX_DOUBLE_TICKET
@@ -44,6 +46,7 @@ public class GameState {
      * e.g. during development or testing.
      */
     public void initializePlayersFromLobby(Lobby lobby) {
+        this.hostId = lobby.getHostId();
         for (User user : lobby.getUsers()) {
             Role role = lobby.getSelectedRole(user.id());
             Player player;
@@ -59,6 +62,32 @@ public class GameState {
                 .filter(id -> !id.equals(mrXId))
                 .collect(Collectors.toSet());
         roundController.initDetectives(detectiveIds);
+    }
+
+    /**
+     * Removes a player from the running game (used when host kicks a disconnected player).
+     * Returns the result type after kick: "MRX_KICKED" if MrX was kicked,
+     * "TOO_FEW_PLAYERS" if less than 3 players remain, or "CONTINUE" otherwise.
+     */
+    public String kickPlayer(String requesterId, String targetId) {
+        if (!requesterId.equals(hostId)) {
+            throw new IllegalStateException("Only the host can kick players");
+        }
+        if (!players.containsKey(targetId)) {
+            throw new IllegalArgumentException("Player not in game");
+        }
+        boolean wasMrX = targetId.equals(mrXId);
+        players.remove(targetId);
+        playerPositions.remove(targetId);
+        if (!wasMrX) roundController.lockDetective(targetId);
+
+        if (wasMrX) {
+            return "MRX_KICKED";
+        }
+        if (players.size() < 2) {
+            return "TOO_FEW_PLAYERS";
+        }
+        return "CONTINUE";
     }
 
     public int assignStartPosition(String playerId) {
@@ -277,6 +306,14 @@ public class GameState {
 
     public Integer getPlayerPosition(String playerId) {
         return playerPositions.get(playerId);
+    }
+
+    public Map<String, String> getPlayerNames() {
+        Map<String, String> names = new HashMap<>();
+        for (Map.Entry<String, Player> entry : players.entrySet()) {
+            names.put(entry.getKey(), entry.getValue().getPlayerName());
+        }
+        return names;
     }
 
     public Player getPlayer(String playerId) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/lobby/Lobby.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/lobby/Lobby.java
@@ -58,6 +58,20 @@ public class Lobby {
         selectedRoles.put(user.id(), Role.NONE);
     }
 
+    /**
+     * Allows a player to rejoin after disconnect.
+     * Skips the isStarted/isLocked check since the player was already in the game.
+     */
+    public void rejoinUser(User user) {
+        if (isFull() && !users.containsKey(user.id())) {
+            throw new IllegalStateException("Lobby is full");
+        }
+        users.put(user.id(), user);
+        // Restore ready status and role if not already present
+        readyStatus.putIfAbsent(user.id(), false);
+        selectedRoles.putIfAbsent(user.id(), Role.NONE);
+    }
+
     public void removeUser(String userId) {
         users.remove(userId);
         readyStatus.remove(userId);

--- a/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
@@ -3,11 +3,17 @@ package at.aau.serg.websocketdemoserver.mapper;
 import at.aau.serg.websocketdemoserver.dtos.game.GameStateDto;
 import at.aau.serg.websocketdemoserver.gamelogic.GameState;
 
-public class GameStateMapper {
+import java.util.Collections;
+import java.util.Set;
 
+public class GameStateMapper {
     private GameStateMapper() {}
 
     public static GameStateDto toDto(GameState gameState) {
+        return toDto(gameState, Collections.emptySet());
+    }
+
+    public static GameStateDto toDto(GameState gameState, Set<String> disconnectedPlayers) {
         return new GameStateDto(
                 gameState.getGameId(),
                 gameState.getCurrentRound(),
@@ -22,7 +28,8 @@ public class GameStateMapper {
                 gameState.getMrXMoveHistory(),
                 gameState.getMrXRevealedPositions(),
                 gameState.allPlayersHaveStartPosition(),
-                gameState.getPlayerNames()
+                gameState.getPlayerNames(),
+                disconnectedPlayers
         );
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/mapper/GameStateMapper.java
@@ -11,6 +11,7 @@ public class GameStateMapper {
         return new GameStateDto(
                 gameState.getGameId(),
                 gameState.getCurrentRound(),
+                gameState.getHostId(),
                 gameState.getCurrentPhase(),
                 gameState.getDetectivePositions(),
                 gameState.getMrXPosition(),
@@ -20,7 +21,8 @@ public class GameStateMapper {
                 gameState.getMrXSpecialTickets(),
                 gameState.getMrXMoveHistory(),
                 gameState.getMrXRevealedPositions(),
-                gameState.allPlayersHaveStartPosition()
+                gameState.allPlayersHaveStartPosition(),
+                gameState.getPlayerNames()
         );
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/LobbyService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/LobbyService.java
@@ -59,7 +59,7 @@ public class LobbyService {
                 .anyMatch(existingUser -> existingUser.id().equals(user.id()));
 
         if (alreadyInLobby) {
-            throw new IllegalStateException("User already in lobby");
+            return lobby; // Reconnect: user is already in lobby, just return it
         }
 
         lobby.addUser(user);

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/LobbyService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/LobbyService.java
@@ -65,6 +65,30 @@ public class LobbyService {
         lobby.addUser(user);
         return lobby;
     }
+    /**
+     * Rejoin a lobby after disconnect.
+     * If the player is already in the lobby, returns the lobby directly (no error).
+     * If the player is not in the lobby anymore, adds them back.
+     */
+    public Lobby rejoinLobby(String lobbyId, User user) {
+        Lobby lobby = activeLobbies.get(lobbyId);
+
+        if (lobby == null) {
+            throw new IllegalArgumentException("Lobby not found");
+        }
+
+        // Player is already in the lobby (e.g. just briefly disconnected)
+        boolean alreadyInLobby = lobby.getUsers().stream()
+                .anyMatch(existingUser -> existingUser.id().equals(user.id()));
+
+        if (alreadyInLobby) {
+            return lobby; // Just return the current lobby state
+        }
+
+        // Player was removed, add them back
+        lobby.rejoinUser(user);
+        return lobby;
+    }
 
     public void leaveLobby(String lobbyId, String userId) {
         Lobby lobby = activeLobbies.get(lobbyId);

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/PlayerSessionService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/PlayerSessionService.java
@@ -1,0 +1,70 @@
+package at.aau.serg.websocketdemoserver.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks which lobby and game each player is currently in.
+ * Used for Game State Recovery on disconnect/reconnect.
+ */
+@Service
+public class PlayerSessionService {
+
+    // userId -> lobbyId
+    private final Map<String, String> playerLobbyMap = new ConcurrentHashMap<>();
+
+    // userId -> gameId
+    private final Map<String, String> playerGameMap = new ConcurrentHashMap<>();
+
+    // ── Lobby tracking ─────────────────────────────────────────────────────
+
+    public void playerJoinedLobby(String userId, String lobbyId) {
+        playerLobbyMap.put(userId, lobbyId);
+    }
+
+    public void playerLeftLobby(String userId) {
+        playerLobbyMap.remove(userId);
+    }
+
+    public String getLobbyForPlayer(String userId) {
+        return playerLobbyMap.get(userId);
+    }
+
+    public boolean isPlayerInLobby(String userId) {
+        return playerLobbyMap.containsKey(userId);
+    }
+
+    // ── Game tracking ──────────────────────────────────────────────────────
+
+    public void playerJoinedGame(String userId, String gameId) {
+        playerGameMap.put(userId, gameId);
+        // Player is in a game, no need to track lobby anymore
+        playerLobbyMap.remove(userId);
+    }
+
+    public void playerLeftGame(String userId) {
+        playerGameMap.remove(userId);
+    }
+
+    public String getGameForPlayer(String userId) {
+        return playerGameMap.get(userId);
+    }
+
+    public boolean isPlayerInGame(String userId) {
+        return playerGameMap.containsKey(userId);
+    }
+
+    // ── Full cleanup ───────────────────────────────────────────────────────
+
+    public void playerDisconnected(String userId) {
+        // Do NOT remove from maps on disconnect!
+        // We keep the mapping so the player can rejoin.
+    }
+
+    public void playerFullyLeft(String userId) {
+        playerLobbyMap.remove(userId);
+        playerGameMap.remove(userId);
+    }
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/SessionAuthService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/SessionAuthService.java
@@ -1,21 +1,21 @@
 package at.aau.serg.websocketdemoserver.service;
 
 import org.springframework.stereotype.Service;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Tracks which STOMP session belongs to which userId.
- * Used to verify that a user is allowed to make calls for themselves only.
- */
 @Service
 public class SessionAuthService {
 
     private final Map<String, String> sessionToUser = new ConcurrentHashMap<>();
+    private final Set<String> disconnectedUsers = ConcurrentHashMap.newKeySet();
 
     public void bindSession(String sessionId, String userId) {
         if (sessionId != null && userId != null) {
             sessionToUser.put(sessionId, userId);
+            disconnectedUsers.remove(userId); // User is back
         }
     }
 
@@ -24,23 +24,31 @@ public class SessionAuthService {
         return sessionToUser.get(sessionId);
     }
 
-    public void unbindSession(String sessionId) {
-        if (sessionId != null) {
-            sessionToUser.remove(sessionId);
+    /**
+     * Called when STOMP session disconnects. Returns the userId that was bound
+     * to that session, or null if none. Marks the user as disconnected.
+     */
+    public String unbindSession(String sessionId) {
+        if (sessionId == null) return null;
+        String userId = sessionToUser.remove(sessionId);
+        if (userId != null) {
+            disconnectedUsers.add(userId);
         }
+        return userId;
     }
 
-    /**
-     * Verify that the given userId in a message matches the userId bound to the session.
-     * If sessionId is null (e.g. in unit tests where no STOMP session exists),
-     * authorization is skipped and true is returned.
-     * In production, sessionId is always provided by Spring's STOMP infrastructure.
-     */
+    public boolean isUserDisconnected(String userId) {
+        return userId != null && disconnectedUsers.contains(userId);
+    }
+
+    public Set<String> getDisconnectedUsers() {
+        return Collections.unmodifiableSet(disconnectedUsers);
+    }
+
     public boolean isAuthorized(String sessionId, String claimedUserId) {
-        if (sessionId == null) return true; // No session context (tests) – skip check
+        if (sessionId == null) return true;
         if (claimedUserId == null) return false;
         String boundUserId = sessionToUser.get(sessionId);
-        // If session is unknown (never registered), reject
         if (boundUserId == null) return false;
         return claimedUserId.equals(boundUserId);
     }

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/SessionAuthService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/SessionAuthService.java
@@ -1,0 +1,51 @@
+package at.aau.serg.websocketdemoserver.service;
+
+import org.springframework.stereotype.Service;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Tracks which STOMP session belongs to which userId.
+ * Used to verify that a user is allowed to make calls for themselves only.
+ */
+@Service
+public class SessionAuthService {
+
+    private final Map<String, String> sessionToUser = new ConcurrentHashMap<>();
+
+    public void bindSession(String sessionId, String userId) {
+        if (sessionId != null && userId != null) {
+            sessionToUser.put(sessionId, userId);
+        }
+    }
+
+    public String getUserForSession(String sessionId) {
+        if (sessionId == null) return null;
+        return sessionToUser.get(sessionId);
+    }
+
+    public void unbindSession(String sessionId) {
+        if (sessionId != null) {
+            sessionToUser.remove(sessionId);
+        }
+    }
+
+    /**
+     * Verify that the given userId in a message matches the userId bound to the session.
+     * If sessionId is null (e.g. in unit tests where no STOMP session exists),
+     * authorization is skipped and true is returned.
+     * In production, sessionId is always provided by Spring's STOMP infrastructure.
+     */
+    public boolean isAuthorized(String sessionId, String claimedUserId) {
+        if (sessionId == null) return true; // No session context (tests) – skip check
+        if (claimedUserId == null) return false;
+        String boundUserId = sessionToUser.get(sessionId);
+        // If session is unknown (never registered), reject
+        if (boundUserId == null) return false;
+        return claimedUserId.equals(boundUserId);
+    }
+
+    public int getSessionCount() {
+        return sessionToUser.size();
+    }
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/service/UserService.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
         }
 
         if (activeUsers.containsKey(lowerCaseName)) {
-            throw new IllegalArgumentException("Nickname already taken");
+            return activeUsers.get(lowerCaseName); // Reconnect: return existing user
         }
 
         String generatedUserId = String.valueOf(userIdSequence.getAndIncrement());

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/StompDisconnectListener.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/StompDisconnectListener.java
@@ -1,0 +1,61 @@
+package at.aau.serg.websocketdemoserver.websocket.broker;
+
+import at.aau.serg.websocketdemoserver.dtos.game.GameStateDto;
+import at.aau.serg.websocketdemoserver.gamelogic.GameState;
+import at.aau.serg.websocketdemoserver.mapper.GameStateMapper;
+import at.aau.serg.websocketdemoserver.service.GameController;
+import at.aau.serg.websocketdemoserver.service.PlayerSessionService;
+import at.aau.serg.websocketdemoserver.service.SessionAuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+/**
+ * Listens for STOMP session disconnects. When a user disconnects:
+ * 1. Mark the user as disconnected in SessionAuthService
+ * 2. If the user is in a running game, broadcast the updated GameState
+ *    so other players (especially the host) see the disconnect.
+ */
+@Component
+public class StompDisconnectListener implements ApplicationListener<SessionDisconnectEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(StompDisconnectListener.class);
+
+    private final SessionAuthService sessionAuthService;
+    private final PlayerSessionService playerSessionService;
+    private final GameController gameController;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public StompDisconnectListener(SessionAuthService sessionAuthService,
+                                   PlayerSessionService playerSessionService,
+                                   GameController gameController,
+                                   SimpMessagingTemplate messagingTemplate) {
+        this.sessionAuthService = sessionAuthService;
+        this.playerSessionService = playerSessionService;
+        this.gameController = gameController;
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Override
+    public void onApplicationEvent(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        String userId = sessionAuthService.unbindSession(sessionId);
+        if (userId == null) {
+            return;
+        }
+        log.info("User {} disconnected (session={})", userId, sessionId);
+
+        // If user is in a running game, broadcast updated GameState
+        String gameId = playerSessionService.getGameForPlayer(userId);
+        if (gameId != null) {
+            GameState gameState = gameController.getGame(gameId);
+            if (gameState != null) {
+                GameStateDto dto = GameStateMapper.toDto(gameState);
+                messagingTemplate.convertAndSend("/topic/game/" + gameId + "/movements", dto);
+            }
+        }
+    }
+}

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerConfig.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerConfig.java
@@ -9,13 +9,11 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketBrokerConfig implements WebSocketMessageBrokerConfigurer {
-
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
         config.enableSimpleBroker("/topic");
         config.setApplicationDestinationPrefixes("/app");
     }
-
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/scotlandyard").setAllowedOrigins("*");

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -16,14 +16,12 @@ import at.aau.serg.websocketdemoserver.gamelogic.turn.TurnType;
 import at.aau.serg.websocketdemoserver.lobby.Lobby;
 import at.aau.serg.websocketdemoserver.lobby.User;
 import at.aau.serg.websocketdemoserver.mapper.GameStateMapper;
-import at.aau.serg.websocketdemoserver.service.GameController;
-import at.aau.serg.websocketdemoserver.service.LobbyService;
-import at.aau.serg.websocketdemoserver.service.PlayerSessionService;
-import at.aau.serg.websocketdemoserver.service.UserService;
+import at.aau.serg.websocketdemoserver.service.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
@@ -38,15 +36,17 @@ public class WebSocketBrokerController {
     private static final Logger log = LoggerFactory.getLogger(WebSocketBrokerController.class);
     private static final String TOPIC_GAME = "/topic/game/";
     private static final String ERROR_TYPE = "ERROR";
+    private static final String UNAUTHORIZED_MSG = "Unauthorized: You can only act on your own behalf";
 
     private final GameController gameController;
     private final LobbyService lobbyService;
     private final SimpMessagingTemplate messagingTemplate;
     private final UserService userService;
     private final PlayerSessionService playerSessionService;
+    private final SessionAuthService sessionAuthService;
 
     public WebSocketBrokerController(SimpMessagingTemplate messagingTemplate) {
-        this(messagingTemplate, GameController.getInstance(), new LobbyService(), new UserService(), new PlayerSessionService());
+        this(messagingTemplate, GameController.getInstance(), new LobbyService(), new UserService(), new PlayerSessionService(), new SessionAuthService());
     }
 
     @Autowired
@@ -54,12 +54,14 @@ public class WebSocketBrokerController {
                                      GameController gameController,
                                      LobbyService lobbyService,
                                      UserService userService,
-                                     PlayerSessionService playerSessionService) {
+                                     PlayerSessionService playerSessionService,
+                                     SessionAuthService sessionAuthService) {
         this.messagingTemplate = messagingTemplate;
         this.gameController = gameController;
         this.lobbyService = lobbyService;
         this.userService = userService;
         this.playerSessionService = playerSessionService;
+        this.sessionAuthService = sessionAuthService;
     }
 
     // ── Messaging helpers ─────────────────────────────────────────────────────
@@ -87,6 +89,31 @@ public class WebSocketBrokerController {
 
     private void broadcastGameOver(String gameId, String result) {
         messagingTemplate.convertAndSend("/topic/game/" + gameId + "/over", result);
+    }
+
+    /**
+     * Returns true and sends a lobby error response if session is not authorized for the claimed userId.
+     * Returns false if session is authorized (caller should proceed).
+     */
+    private boolean denyIfUnauthorized(String sessionId, String claimedUserId, String lobbyIdForResponse) {
+        if (!sessionAuthService.isAuthorized(sessionId, claimedUserId)) {
+            log.warn("Unauthorized call: session={} tried to act as user={}", sessionId, claimedUserId);
+            sendToUser(claimedUserId, new LobbyResponse(false, UNAUTHORIZED_MSG, lobbyIdForResponse, null));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Same as denyIfUnauthorized but sends a movement response (for game-related endpoints).
+     */
+    private boolean denyIfUnauthorizedGame(String sessionId, String claimedUserId) {
+        if (!sessionAuthService.isAuthorized(sessionId, claimedUserId)) {
+            log.warn("Unauthorized game call: session={} tried to act as user={}", sessionId, claimedUserId);
+            sendToUser(claimedUserId, new MovementResponse(false, UNAUTHORIZED_MSG, 0, null));
+            return true;
+        }
+        return false;
     }
 
     private boolean validateStartPositionIds(String gameId, String playerId) {
@@ -129,8 +156,14 @@ public class WebSocketBrokerController {
     @MessageMapping("/user/connect")
     @SendToUser("/topic/user-response")
     public UserConnectResponse handleUserConnect(UserConnectMessage message) {
+        return handleUserConnect(message, null);
+    }
+
+    public UserConnectResponse handleUserConnect(UserConnectMessage message,
+                                                 @Header(value = "simpSessionId", required = false) String sessionId) {
         try {
             User user = userService.registerUser(message.getNickName());
+            sessionAuthService.bindSession(sessionId, user.id());
             return new UserConnectResponse(true, "User registered", user);
         } catch (IllegalArgumentException e) {
             return new UserConnectResponse(false, e.getMessage(), null);
@@ -143,6 +176,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/create")
     public void handleCreateLobby(CreateLobbyMessage message) {
+        handleCreateLobby(message, null);
+    }
+
+    public void handleCreateLobby(CreateLobbyMessage message,
+                                  @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getUserId(), null)) return;
         try {
             User host = new User(message.getUserId(), message.getNickName());
             Lobby lobby = lobbyService.createLobby(message.getLobbyName(), host);
@@ -157,6 +196,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/join")
     public void handleJoinLobby(JoinLobbyMessage message) {
+        handleJoinLobby(message, null);
+    }
+
+    public void handleJoinLobby(JoinLobbyMessage message,
+                                @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getUserId(), message.getLobbyId())) return;
         try {
             User user = new User(message.getUserId(), message.getNickName());
             Lobby lobby = lobbyService.joinLobby(message.getLobbyId(), user);
@@ -173,6 +218,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/leave")
     public void handleLeaveLobby(LeaveLobbyMessage message) {
+        handleLeaveLobby(message, null);
+    }
+
+    public void handleLeaveLobby(LeaveLobbyMessage message,
+                                 @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getUserId(), message.getLobbyId())) return;
         try {
             Lobby lobbyBefore = lobbyService.getLobby(message.getLobbyId());
             User leavingUser = (lobbyBefore != null) ? lobbyBefore.getUsers().stream()
@@ -205,6 +256,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/delete")
     public void handleDeleteLobby(DeleteLobbyMessage message) {
+        handleDeleteLobby(message, null);
+    }
+
+    public void handleDeleteLobby(DeleteLobbyMessage message,
+                                  @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getRequesterId(), message.getLobbyId())) return;
         try {
             Lobby lobbyBefore = lobbyService.getLobby(message.getLobbyId());
             String hostName = (lobbyBefore != null && lobbyBefore.getHost() != null)
@@ -223,6 +280,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/kick")
     public void handleKickPlayer(KickPlayerMessage message) {
+        handleKickPlayer(message, null);
+    }
+
+    public void handleKickPlayer(KickPlayerMessage message,
+                                 @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getRequesterId(), message.getLobbyId())) return;
         try {
             Lobby lobbyBefore = lobbyService.getLobby(message.getLobbyId());
             User targetUser = lobbyBefore.getUsers().stream()
@@ -247,6 +310,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/setRole")
     public void handleSetRole(SetRoleMessage message) {
+        handleSetRole(message, null);
+    }
+
+    public void handleSetRole(SetRoleMessage message,
+                              @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getRequesterId(), message.getLobbyId())) return;
         try {
             Lobby lobby = lobbyService.setRole(
                     message.getLobbyId(),
@@ -267,6 +336,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/startRoleSelection")
     public void handleStartRoleSelection(StartRoleSelectionMessage message) {
+        handleStartRoleSelection(message, null);
+    }
+
+    public void handleStartRoleSelection(StartRoleSelectionMessage message,
+                                         @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getRequesterId(), message.getLobbyId())) return;
         try {
             Lobby lobby = lobbyService.getLobby(message.getLobbyId());
             if (lobby == null) throw new IllegalArgumentException("Lobby not found");
@@ -285,7 +360,13 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/startGame")
     public void handleStartGame(StartGameMessage message) {
+        handleStartGame(message, null);
+    }
+
+    public void handleStartGame(StartGameMessage message,
+                                @Header(value = "simpSessionId", required = false) String sessionId) {
         if (message == null) return;
+        if (denyIfUnauthorized(sessionId, message.getRequesterId(), message.getLobbyId())) return;
         try {
             Lobby lobby = lobbyService.getLobby(message.getLobbyId());
             if (lobby == null) throw new IllegalArgumentException("Lobby not found");
@@ -312,6 +393,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/backToLobby")
     public void handleBackToLobby(BackToLobbyMessage message) {
+        handleBackToLobby(message, null);
+    }
+
+    public void handleBackToLobby(BackToLobbyMessage message,
+                                  @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getRequesterId(), message.getLobbyId())) return;
         try {
             Lobby lobby = lobbyService.getLobby(message.getLobbyId());
             if (lobby == null) throw new IllegalArgumentException("Lobby not found");
@@ -332,6 +419,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/rejoin")
     public void handleRejoinLobby(RejoinLobbyMessage message) {
+        handleRejoinLobby(message, null);
+    }
+
+    public void handleRejoinLobby(RejoinLobbyMessage message,
+                                  @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getUserId(), null)) return;
         try {
             User user = new User(message.getUserId(), message.getNickName());
             Lobby lobby = lobbyService.rejoinLobby(message.getLobbyId(), user);
@@ -346,6 +439,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/game/rejoin")
     public void handleRejoinGame(RejoinGameMessage message) {
+        handleRejoinGame(message, null);
+    }
+
+    public void handleRejoinGame(RejoinGameMessage message,
+                                 @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorized(sessionId, message.getUserId(), null)) return;
         try {
             String gameId = message.getGameId();
 
@@ -397,11 +496,17 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/game/start-position/request")
     public void handleStartPositionRequest(StartPositionRequest request) {
+        handleStartPositionRequest(request, null);
+    }
+
+    public void handleStartPositionRequest(StartPositionRequest request,
+                                           @Header(value = "simpSessionId", required = false) String sessionId) {
         if (request == null) return;
         String gameId = request.getGameId();
         String playerId = request.getPlayerId();
 
         if (!validateStartPositionIds(gameId, playerId)) return;
+        if (denyIfUnauthorizedGame(sessionId, playerId)) return;
 
         String topic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
         GameState gameState = resolveGameState(gameId, playerId, topic);
@@ -420,11 +525,17 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/game/start-position/confirm")
     public void handleConfirmStartPosition(StartPositionConfirmRequest request) {
+        handleConfirmStartPosition(request, null);
+    }
+
+    public void handleConfirmStartPosition(StartPositionConfirmRequest request,
+                                           @Header(value = "simpSessionId", required = false) String sessionId) {
         if (request == null) return;
         String gameId = request.getGameId();
         String playerId = request.getPlayerId();
 
         if (!validateStartPositionIds(gameId, playerId)) return;
+        if (denyIfUnauthorizedGame(sessionId, playerId)) return;
 
         String playerTopic = TOPIC_GAME + gameId + "/player/" + playerId + "/start-position";
         GameState gameState = resolveGameState(gameId, playerId, playerTopic);
@@ -442,6 +553,11 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/game/{gameId}/move")
     public void handleMove(@DestinationVariable String gameId, @Payload MovementMessage movement) {
+        handleMove(gameId, movement, null);
+    }
+
+    public void handleMove(@DestinationVariable String gameId, @Payload MovementMessage movement,
+                           @Header(value = "simpSessionId", required = false) String sessionId) {
         if (movement == null) {
             sendMoveResponse(gameId, new MovementResponse(false, "NULL MESSAGE", 0, null));
             return;
@@ -450,6 +566,7 @@ public class WebSocketBrokerController {
             sendMoveResponse(gameId, new MovementResponse(false, "Invalid movement data: No player ID", 0, null));
             return;
         }
+        if (denyIfUnauthorizedGame(sessionId, movement.getPlayerId())) return;
 
         GameState gameState = gameController.getGame(gameId);
 
@@ -559,6 +676,12 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/game/kickPlayer")
     public void handleKickPlayerInGame(KickPlayerInGameMessage message) {
+        handleKickPlayerInGame(message, null);
+    }
+
+    public void handleKickPlayerInGame(KickPlayerInGameMessage message,
+                                       @Header(value = "simpSessionId", required = false) String sessionId) {
+        if (denyIfUnauthorizedGame(sessionId, message.getRequesterId())) return;
         try {
             GameState gameState = gameController.getGame(message.getGameId());
             if (gameState == null) {

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -30,6 +30,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+import at.aau.serg.websocketdemoserver.dtos.game.KickPlayerInGameMessage;
 
 @Controller
 public class WebSocketBrokerController {
@@ -553,6 +554,33 @@ public class WebSocketBrokerController {
 
         } catch (Exception e) {
             sendToUser(movement.getPlayerId(), new MovementResponse(false, "Error: " + e.getMessage(), 0, null));
+        }
+    }
+
+    @MessageMapping("/game/kickPlayer")
+    public void handleKickPlayerInGame(KickPlayerInGameMessage message) {
+        try {
+            GameState gameState = gameController.getGame(message.getGameId());
+            if (gameState == null) {
+                sendToUser(message.getRequesterId(), new MovementResponse(false, "Game not found", 0, null));
+                return;
+            }
+            String result = gameState.kickPlayer(message.getRequesterId(), message.getTargetId());
+            broadcastGameState(message.getGameId(), gameState);
+
+            switch (result) {
+                case "MRX_KICKED" -> {
+                    broadcastGameOver(message.getGameId(), "DETECTIVES_WIN");
+                    gameController.removeGame(message.getGameId());
+                }
+                case "TOO_FEW_PLAYERS" -> {
+                    broadcastGameOver(message.getGameId(), "DETECTIVES_WIN");
+                    gameController.removeGame(message.getGameId());
+                }
+                default -> { /* continue game */ }
+            }
+        } catch (Exception e) {
+            sendToUser(message.getRequesterId(), new MovementResponse(false, e.getMessage(), 0, null));
         }
     }
 }

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -83,7 +83,7 @@ public class WebSocketBrokerController {
     }
 
     private void broadcastGameState(String gameId, GameState gameState) {
-        GameStateDto dto = GameStateMapper.toDto(gameState);
+        GameStateDto dto = GameStateMapper.toDto(gameState, sessionAuthService.getDisconnectedUsers());
         messagingTemplate.convertAndSend("/topic/game/" + gameId + "/movements", dto);
     }
 

--- a/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
+++ b/src/main/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerController.java
@@ -1,6 +1,7 @@
 package at.aau.serg.websocketdemoserver.websocket.broker;
 
 import at.aau.serg.websocketdemoserver.dtos.game.GameStateDto;
+import at.aau.serg.websocketdemoserver.dtos.game.RejoinGameMessage;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionConfirmRequest;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionRequest;
 import at.aau.serg.websocketdemoserver.dtos.game.StartPositionResponse;
@@ -17,7 +18,10 @@ import at.aau.serg.websocketdemoserver.lobby.User;
 import at.aau.serg.websocketdemoserver.mapper.GameStateMapper;
 import at.aau.serg.websocketdemoserver.service.GameController;
 import at.aau.serg.websocketdemoserver.service.LobbyService;
+import at.aau.serg.websocketdemoserver.service.PlayerSessionService;
 import at.aau.serg.websocketdemoserver.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -25,8 +29,6 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -34,39 +36,41 @@ public class WebSocketBrokerController {
 
     private static final Logger log = LoggerFactory.getLogger(WebSocketBrokerController.class);
     private static final String TOPIC_GAME = "/topic/game/";
+    private static final String ERROR_TYPE = "ERROR";
 
     private final GameController gameController;
     private final LobbyService lobbyService;
     private final SimpMessagingTemplate messagingTemplate;
     private final UserService userService;
+    private final PlayerSessionService playerSessionService;
 
-    // constructor for tests
     public WebSocketBrokerController(SimpMessagingTemplate messagingTemplate) {
-        this(messagingTemplate, GameController.getInstance(), new LobbyService(), new UserService());
+        this(messagingTemplate, GameController.getInstance(), new LobbyService(), new UserService(), new PlayerSessionService());
     }
 
     @Autowired
     public WebSocketBrokerController(SimpMessagingTemplate messagingTemplate,
                                      GameController gameController,
                                      LobbyService lobbyService,
-                                     UserService userService) {
+                                     UserService userService,
+                                     PlayerSessionService playerSessionService) {
         this.messagingTemplate = messagingTemplate;
         this.gameController = gameController;
         this.lobbyService = lobbyService;
         this.userService = userService;
+        this.playerSessionService = playerSessionService;
     }
 
-    // 1. Private Antworten an den Auslöser über das dedizierte Player-Topic
+    // ── Messaging helpers ─────────────────────────────────────────────────────
+
     private void sendToUser(String userId, Object payload) {
         messagingTemplate.convertAndSend("/topic/player/" + userId, payload);
     }
 
-    // 2. Globale Antworten (NUR für den Server-Browser: Erstellen & Löschen)
     private void broadcastToGlobalLobbyList(LobbyResponse response) {
         messagingTemplate.convertAndSend("/topic/lobby", response);
     }
 
-    // 3. Isolierte Antworten (NUR für die Spieler, die physisch IN dieser Lobby sind)
     private void broadcastToSpecificLobby(String lobbyId, LobbyResponse response) {
         messagingTemplate.convertAndSend("/topic/lobby/" + lobbyId, response);
     }
@@ -87,12 +91,12 @@ public class WebSocketBrokerController {
     private boolean validateStartPositionIds(String gameId, String playerId) {
         if (gameId == null || gameId.isBlank()) {
             messagingTemplate.convertAndSend("/topic/game/error",
-                    new StartPositionResponse("ERROR", null, null, null, "gameId must not be blank"));
+                    new StartPositionResponse(ERROR_TYPE, null, null, null, "gameId must not be blank"));
             return false;
         }
         if (playerId == null || playerId.isBlank()) {
             messagingTemplate.convertAndSend(TOPIC_GAME + gameId + "/player/unknown/start-position",
-                    new StartPositionResponse("ERROR", gameId, "unknown", null, "playerId must not be blank"));
+                    new StartPositionResponse(ERROR_TYPE, gameId, "unknown", null, "playerId must not be blank"));
             return false;
         }
         return true;
@@ -102,10 +106,12 @@ public class WebSocketBrokerController {
         GameState gameState = gameController.getGame(gameId);
         if (gameState == null) {
             messagingTemplate.convertAndSend(playerTopic,
-                    new StartPositionResponse("ERROR", gameId, playerId, null, "Game not found"));
+                    new StartPositionResponse(ERROR_TYPE, gameId, playerId, null, "Game not found"));
         }
         return gameState;
     }
+
+    // ── Basic endpoints ───────────────────────────────────────────────────────
 
     @MessageMapping("/hello")
     @SendTo("/topic/hello-response")
@@ -124,24 +130,23 @@ public class WebSocketBrokerController {
     public UserConnectResponse handleUserConnect(UserConnectMessage message) {
         try {
             User user = userService.registerUser(message.getNickName());
-            UserConnectResponse response = new UserConnectResponse(true, "User registered", user);
-            return response;
+            return new UserConnectResponse(true, "User registered", user);
         } catch (IllegalArgumentException e) {
-            UserConnectResponse response = new UserConnectResponse(false, e.getMessage(), null);
-            return response;
+            return new UserConnectResponse(false, e.getMessage(), null);
         } catch (Exception e) {
-            UserConnectResponse response = new UserConnectResponse(false, "Internal Server Error", null);
-            return response;
+            return new UserConnectResponse(false, "Internal Server Error", null);
         }
     }
+
+    // ── Lobby endpoints ───────────────────────────────────────────────────────
 
     @MessageMapping("/lobby/create")
     public void handleCreateLobby(CreateLobbyMessage message) {
         try {
             User host = new User(message.getUserId(), message.getNickName());
             Lobby lobby = lobbyService.createLobby(message.getLobbyName(), host);
+            playerSessionService.playerJoinedLobby(message.getUserId(), lobby.getId());
             LobbyResponse response = new LobbyResponse(true, message.getNickName() + "'s Lobby created", lobby.getId(), lobby);
-
             sendToUser(message.getUserId(), response);
             broadcastToGlobalLobbyList(response);
         } catch (Exception e) {
@@ -154,10 +159,10 @@ public class WebSocketBrokerController {
         try {
             User user = new User(message.getUserId(), message.getNickName());
             Lobby lobby = lobbyService.joinLobby(message.getLobbyId(), user);
+            playerSessionService.playerJoinedLobby(message.getUserId(), lobby.getId());
             String hostName = lobby.getHost().nickName();
             String responseMessage = message.getNickName() + " joined " + hostName + "'s Lobby";
             LobbyResponse response = new LobbyResponse(true, responseMessage, lobby.getId(), lobby);
-
             sendToUser(message.getUserId(), response);
             broadcastToSpecificLobby(lobby.getId(), response);
         } catch (Exception e) {
@@ -173,9 +178,11 @@ public class WebSocketBrokerController {
                     .filter(u -> u.id().equals(message.getUserId()))
                     .findFirst().orElse(null) : null;
             String leavingUserName = (leavingUser != null) ? leavingUser.nickName() : "Unknown";
-            String hostNameBefore = (lobbyBefore != null && lobbyBefore.getHost() != null) ? lobbyBefore.getHost().nickName() : "Unknown";
+            String hostNameBefore = (lobbyBefore != null && lobbyBefore.getHost() != null)
+                    ? lobbyBefore.getHost().nickName() : "Unknown";
 
             lobbyService.leaveLobby(message.getLobbyId(), message.getUserId());
+            playerSessionService.playerFullyLeft(message.getUserId());
             Lobby updatedLobby = lobbyService.getLobby(message.getLobbyId());
 
             if (updatedLobby == null) {
@@ -199,12 +206,12 @@ public class WebSocketBrokerController {
     public void handleDeleteLobby(DeleteLobbyMessage message) {
         try {
             Lobby lobbyBefore = lobbyService.getLobby(message.getLobbyId());
-            String hostName = (lobbyBefore != null && lobbyBefore.getHost() != null) ? lobbyBefore.getHost().nickName() : "Unknown";
-
+            String hostName = (lobbyBefore != null && lobbyBefore.getHost() != null)
+                    ? lobbyBefore.getHost().nickName() : "Unknown";
             lobbyService.deleteLobby(message.getLobbyId(), message.getRequesterId());
+            playerSessionService.playerFullyLeft(message.getRequesterId());
             String responseMessage = hostName + " deleted the Lobby";
             LobbyResponse response = new LobbyResponse(true, responseMessage, message.getLobbyId(), null);
-
             sendToUser(message.getRequesterId(), response);
             broadcastToSpecificLobby(message.getLobbyId(), response);
             broadcastToGlobalLobbyList(response);
@@ -221,16 +228,15 @@ public class WebSocketBrokerController {
                     .filter(u -> u.id().equals(message.getTargetUserId()))
                     .findFirst().orElse(null);
             String targetNickName = (targetUser != null) ? targetUser.nickName() : "Unknown";
-
             Lobby lobby = lobbyService.kickPlayer(
                     message.getLobbyId(),
                     message.getRequesterId(),
                     message.getTargetUserId()
             );
+            playerSessionService.playerFullyLeft(message.getTargetUserId());
             String hostName = lobby.getHost().nickName();
             String responseMessage = targetNickName + " was kicked out of " + hostName + "'s Lobby";
             LobbyResponse response = new LobbyResponse(true, responseMessage, lobby.getId(), lobby);
-
             sendToUser(message.getTargetUserId(), response);
             broadcastToSpecificLobby(lobby.getId(), response);
         } catch (Exception e) {
@@ -265,12 +271,10 @@ public class WebSocketBrokerController {
             if (lobby == null) throw new IllegalArgumentException("Lobby not found");
             if (!lobby.getHostId().equals(message.getRequesterId()))
                 throw new IllegalStateException("Only host can start role selection");
-
             lobby.setLocked(true);
             String hostName = lobby.getHost().nickName();
             String responseMessage = hostName + " started role selection";
             LobbyResponse response = new LobbyResponse(true, responseMessage, lobby.getId(), lobby);
-
             sendToUser(message.getRequesterId(), response);
             broadcastToSpecificLobby(lobby.getId(), response);
         } catch (Exception e) {
@@ -280,9 +284,7 @@ public class WebSocketBrokerController {
 
     @MessageMapping("/lobby/startGame")
     public void handleStartGame(StartGameMessage message) {
-        if (message == null) {
-            return;
-        }
+        if (message == null) return;
         try {
             Lobby lobby = lobbyService.getLobby(message.getLobbyId());
             if (lobby == null) throw new IllegalArgumentException("Lobby not found");
@@ -297,19 +299,13 @@ public class WebSocketBrokerController {
             gameState.initializePlayersFromLobby(lobby);
             gameController.addGame(lobby.getId(), gameState);
 
-            broadcastToSpecificLobby(lobby.getId(), new LobbyResponse(true, "GAME_STARTED", lobby.getId(), lobby));
+            lobby.getUsers().forEach(u ->
+                    playerSessionService.playerJoinedGame(u.id(), lobby.getId()));
 
+            broadcastToSpecificLobby(lobby.getId(), new LobbyResponse(true, "GAME_STARTED", lobby.getId(), lobby));
             broadcastGameState(lobby.getId(), gameState);
         } catch (Exception e) {
             sendToUser(message.getRequesterId(), new LobbyResponse(false, e.getMessage(), message.getLobbyId(), null));
-        }
-    }
-
-    @MessageMapping("/game/{gameId}/state")
-    public void handleGetGameState(@DestinationVariable String gameId) {
-        GameState gameState = gameController.getGame(gameId);
-        if (gameState != null) {
-            broadcastGameState(gameId, gameState);
         }
     }
 
@@ -320,12 +316,10 @@ public class WebSocketBrokerController {
             if (lobby == null) throw new IllegalArgumentException("Lobby not found");
             if (!lobby.getHostId().equals(message.getRequesterId()))
                 throw new IllegalStateException("Only host can go back to lobby");
-
             lobby.setLocked(false);
             String hostName = lobby.getHost().nickName();
             String responseMessage = hostName + " returned to Lobby";
             LobbyResponse response = new LobbyResponse(true, responseMessage, lobby.getId(), lobby);
-
             sendToUser(message.getRequesterId(), response);
             broadcastToSpecificLobby(lobby.getId(), response);
         } catch (Exception e) {
@@ -333,11 +327,76 @@ public class WebSocketBrokerController {
         }
     }
 
+    // ── Game State Recovery endpoints ─────────────────────────────────────────
+
+    @MessageMapping("/lobby/rejoin")
+    public void handleRejoinLobby(RejoinLobbyMessage message) {
+        try {
+            User user = new User(message.getUserId(), message.getNickName());
+            Lobby lobby = lobbyService.rejoinLobby(message.getLobbyId(), user);
+            playerSessionService.playerJoinedLobby(message.getUserId(), lobby.getId());
+            LobbyResponse response = new LobbyResponse(true, "Rejoined lobby", lobby.getId(), lobby);
+            sendToUser(message.getUserId(), response);
+            broadcastToSpecificLobby(lobby.getId(), response);
+        } catch (Exception e) {
+            sendToUser(message.getUserId(), new LobbyResponse(false, e.getMessage(), null, null));
+        }
+    }
+
+    @MessageMapping("/game/rejoin")
+    public void handleRejoinGame(RejoinGameMessage message) {
+        try {
+            String gameId = message.getGameId();
+
+            if (gameId == null || gameId.isBlank()) {
+                gameId = playerSessionService.getGameForPlayer(message.getUserId());
+            }
+
+            if (gameId == null) {
+                String lobbyId = playerSessionService.getLobbyForPlayer(message.getUserId());
+                if (lobbyId != null) {
+                    Lobby lobby = lobbyService.getLobby(lobbyId);
+                    if (lobby != null) {
+                        sendToUser(message.getUserId(),
+                                new LobbyResponse(true, "Rejoined lobby", lobby.getId(), lobby));
+                        return;
+                    }
+                }
+                sendToUser(message.getUserId(),
+                        new LobbyResponse(false, "No active game or lobby found", null, null));
+                return;
+            }
+
+            GameState gameState = gameController.getGame(gameId);
+            if (gameState == null) {
+                sendToUser(message.getUserId(),
+                        new LobbyResponse(false, "Game not found", null, null));
+                return;
+            }
+
+            messagingTemplate.convertAndSend(
+                    "/topic/game/" + gameId + "/movements",
+                    GameStateMapper.toDto(gameState)
+            );
+        } catch (Exception e) {
+            sendToUser(message.getUserId(),
+                    new LobbyResponse(false, e.getMessage(), null, null));
+        }
+    }
+
+    // ── Game endpoints ────────────────────────────────────────────────────────
+
+    @MessageMapping("/game/{gameId}/state")
+    public void handleGetGameState(@DestinationVariable String gameId) {
+        GameState gameState = gameController.getGame(gameId);
+        if (gameState != null) {
+            broadcastGameState(gameId, gameState);
+        }
+    }
+
     @MessageMapping("/game/start-position/request")
     public void handleStartPositionRequest(StartPositionRequest request) {
-        if (request == null) {
-            return; // no recipient address available – silently ignore
-        }
+        if (request == null) return;
         String gameId = request.getGameId();
         String playerId = request.getPlayerId();
 
@@ -351,20 +410,17 @@ public class WebSocketBrokerController {
             int position = gameState.assignStartPosition(playerId, request.getSelectedStartPosition());
             messagingTemplate.convertAndSend(topic,
                     new StartPositionResponse("START_POSITION_ASSIGNED", gameId, playerId, position, null));
-            // Broadcast the updated board state so every client renders the new figure immediately
             broadcastGameState(gameId, gameState);
         } catch (Exception e) {
             messagingTemplate.convertAndSend(topic,
-                    new StartPositionResponse("ERROR", gameId, playerId, null, e.getMessage()));
+                    new StartPositionResponse(ERROR_TYPE, gameId, playerId, null, e.getMessage()));
         }
     }
 
     @MessageMapping("/game/start-position/confirm")
     public void handleConfirmStartPosition(StartPositionConfirmRequest request) {
-        if (request == null) {
-            return; // no recipient address available – silently ignore
-        }
-        String gameId  = request.getGameId();
+        if (request == null) return;
+        String gameId = request.getGameId();
         String playerId = request.getPlayerId();
 
         if (!validateStartPositionIds(gameId, playerId)) return;
@@ -375,19 +431,16 @@ public class WebSocketBrokerController {
 
         try {
             int confirmedPosition = gameState.confirmStartPosition(playerId, request.getStartPosition());
-            // Respond ONLY to the requesting player – no board-state broadcast
             messagingTemplate.convertAndSend(playerTopic,
-                    new StartPositionResponse("START_POSITION_CONFIRMED", gameId, playerId,
-                            confirmedPosition, null));
+                    new StartPositionResponse("START_POSITION_CONFIRMED", gameId, playerId, confirmedPosition, null));
         } catch (Exception e) {
             messagingTemplate.convertAndSend(playerTopic,
-                    new StartPositionResponse("ERROR", gameId, playerId, null, e.getMessage()));
+                    new StartPositionResponse(ERROR_TYPE, gameId, playerId, null, e.getMessage()));
         }
     }
 
     @MessageMapping("/game/{gameId}/move")
     public void handleMove(@DestinationVariable String gameId, @Payload MovementMessage movement) {
-
         if (movement == null) {
             sendMoveResponse(gameId, new MovementResponse(false, "NULL MESSAGE", 0, null));
             return;
@@ -496,7 +549,6 @@ public class WebSocketBrokerController {
 
             String extra = (isMrX && gameState.getRoundController().isDoubleMoveActive())
                     ? " (1 move remaining due to double move ticket)" : "";
-
             sendMoveResponse(gameId, new MovementResponse(true, "Movement successful" + extra, gameState.getPlayerPosition(movement.getPlayerId()), null));
 
         } catch (Exception e) {

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
@@ -14,6 +14,7 @@ class GameStateDtoTest {
         return new GameStateDto(
                 gameId,
                 round,
+                "host1",
                 phase,
                 Map.of("det1", 10),
                 99,
@@ -23,7 +24,8 @@ class GameStateDtoTest {
                 Map.of("BLACK", 5, "DOUBLE", 2),
                 List.of("WALKING", "ESCOOTER"),
                 Map.of(3, 42),
-                true
+                true,
+                Map.of()
         );
     }
 
@@ -84,8 +86,8 @@ class GameStateDtoTest {
 
     @Test
     void testNullMrXPosition() {
-        GameStateDto dto = new GameStateDto("g1", 1, TurnType.MRX,
-                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false);
+        GameStateDto dto = new GameStateDto("g1", 1, "host1", TurnType.MRX,
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false, Map.of());
         assertThat(dto.getMrXPosition()).isNull();
     }
 
@@ -94,8 +96,8 @@ class GameStateDtoTest {
         GameStateDto ready = buildDto("g1", 1, TurnType.MRX);
         assertThat(ready.isAllPlayersReady()).isTrue();
 
-        GameStateDto notReady = new GameStateDto("g1", 1, TurnType.MRX,
-                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false);
+        GameStateDto notReady = new GameStateDto("g1", 1, "host1", TurnType.MRX,
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false, Map.of());
         assertThat(notReady.isAllPlayersReady()).isFalse();
     }
 

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/GameStateDtoTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +26,8 @@ class GameStateDtoTest {
                 List.of("WALKING", "ESCOOTER"),
                 Map.of(3, 42),
                 true,
-                Map.of()
+                Map.of(),
+                Set.of()
         );
     }
 
@@ -87,7 +89,7 @@ class GameStateDtoTest {
     @Test
     void testNullMrXPosition() {
         GameStateDto dto = new GameStateDto("g1", 1, "host1", TurnType.MRX,
-                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false, Map.of());
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false, Map.of(), Set.of());
         assertThat(dto.getMrXPosition()).isNull();
     }
 
@@ -97,7 +99,7 @@ class GameStateDtoTest {
         assertThat(ready.isAllPlayersReady()).isTrue();
 
         GameStateDto notReady = new GameStateDto("g1", 1, "host1", TurnType.MRX,
-                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false, Map.of());
+                Map.of(), null, false, 1, Map.of(), Map.of(), List.of(), Map.of(), false, Map.of(), Set.of());
         assertThat(notReady.isAllPlayersReady()).isFalse();
     }
 

--- a/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/KickPlayerInGameMessageTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/dtos/game/KickPlayerInGameMessageTest.java
@@ -1,0 +1,27 @@
+package at.aau.serg.websocketdemoserver.dtos.game;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class KickPlayerInGameMessageTest {
+
+    @Test
+    void testGettersAndSetters() {
+        KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
+        msg.setGameId("g1");
+        msg.setRequesterId("host1");
+        msg.setTargetId("target1");
+
+        assertEquals("g1", msg.getGameId());
+        assertEquals("host1", msg.getRequesterId());
+        assertEquals("target1", msg.getTargetId());
+    }
+
+    @Test
+    void testDefaultsNull() {
+        KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
+        assertNull(msg.getGameId());
+        assertNull(msg.getRequesterId());
+        assertNull(msg.getTargetId());
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateKickPlayerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/gamelogic/GameStateKickPlayerTest.java
@@ -1,0 +1,97 @@
+package at.aau.serg.websocketdemoserver.gamelogic;
+
+import at.aau.serg.websocketdemoserver.lobby.Lobby;
+import at.aau.serg.websocketdemoserver.lobby.Role;
+import at.aau.serg.websocketdemoserver.lobby.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GameStateKickPlayerTest {
+
+    private GameState gameState;
+    private Lobby mockLobby;
+    private User host;
+    private User detective1;
+    private User detective2;
+    private User mrX;
+
+    @BeforeEach
+    void setUp() {
+        gameState = new GameState("game1");
+        host = new User("host1", "Host");
+        detective1 = new User("det1", "Detective1");
+        detective2 = new User("det2", "Detective2");
+        mrX = new User("mrx1", "MrX");
+
+        mockLobby = mock(Lobby.class);
+        when(mockLobby.getHostId()).thenReturn("host1");
+        when(mockLobby.getUsers()).thenReturn(Arrays.asList(host, detective1, detective2, mrX));
+        when(mockLobby.getSelectedRole("host1")).thenReturn(Role.DETECTIVE);
+        when(mockLobby.getSelectedRole("det1")).thenReturn(Role.DETECTIVE);
+        when(mockLobby.getSelectedRole("det2")).thenReturn(Role.DETECTIVE);
+        when(mockLobby.getSelectedRole("mrx1")).thenReturn(Role.MRX);
+
+        gameState.initializePlayersFromLobby(mockLobby);
+    }
+
+    @Test
+    void testHostIdIsSetFromLobby() {
+        assertEquals("host1", gameState.getHostId());
+    }
+
+    @Test
+    void testGetPlayerNamesReturnsAllPlayers() {
+        Map<String, String> names = gameState.getPlayerNames();
+        assertEquals(4, names.size());
+        assertEquals("Host", names.get("host1"));
+        assertEquals("Detective1", names.get("det1"));
+        assertEquals("MrX", names.get("mrx1"));
+    }
+
+    @Test
+    void testKickPlayerByNonHostThrows() {
+        assertThrows(IllegalStateException.class,
+                () -> gameState.kickPlayer("det1", "det2"));
+    }
+
+    @Test
+    void testKickUnknownPlayerThrows() {
+        assertThrows(IllegalArgumentException.class,
+                () -> gameState.kickPlayer("host1", "unknown"));
+    }
+
+    @Test
+    void testKickMrXReturnsMrXKicked() {
+        String result = gameState.kickPlayer("host1", "mrx1");
+        assertEquals("MRX_KICKED", result);
+    }
+
+    @Test
+    void testKickDetectiveContinuesGame() {
+        String result = gameState.kickPlayer("host1", "det1");
+        assertEquals("CONTINUE", result);
+    }
+
+    @Test
+    void testKickPlayerRemovesFromPlayerNames() {
+        gameState.kickPlayer("host1", "det1");
+        assertFalse(gameState.getPlayerNames().containsKey("det1"));
+    }
+
+    @Test
+    void testKickUntilTooFewPlayers() {
+        // Start with 4: host, det1, det2, mrx1
+        // Kick 2 detectives, then kick host (still detective in role)
+        // After 3 kicks, only mrX remains -> < 2 players
+        gameState.kickPlayer("host1", "det1");
+        gameState.kickPlayer("host1", "det2");
+        String result = gameState.kickPlayer("host1", "host1");
+        assertEquals("TOO_FEW_PLAYERS", result);
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/lobby/LobbyRejoinTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/lobby/LobbyRejoinTest.java
@@ -50,4 +50,29 @@ class LobbyRejoinTest {
         lobby.rejoinUser(user);
         assertEquals(Role.NONE, lobby.getSelectedRole("2"));
     }
+
+    @Test
+    void testRejoinUserThrowsWhenLobbyIsFullAndUserNotInside() {
+        User host = new User("1", "Host");
+        Lobby lobby = new Lobby("TestLobby", host);
+        // Fill lobby to capacity (max 6)
+        for (int i = 2; i <= 6; i++) {
+            lobby.addUser(new User(String.valueOf(i), "User" + i));
+        }
+        User newUser = new User("99", "NewUser");
+        assertThrows(IllegalStateException.class, () -> lobby.rejoinUser(newUser));
+    }
+
+    @Test
+    void testRejoinUserSucceedsWhenLobbyIsFullButUserAlreadyInside() {
+        User host = new User("1", "Host");
+        Lobby lobby = new Lobby("TestLobby", host);
+        User existing = new User("2", "Existing");
+        lobby.addUser(existing);
+        for (int i = 3; i <= 6; i++) {
+            lobby.addUser(new User(String.valueOf(i), "User" + i));
+        }
+        // existing user should be able to rejoin even though lobby is full
+        assertDoesNotThrow(() -> lobby.rejoinUser(existing));
+    }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/lobby/LobbyRejoinTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/lobby/LobbyRejoinTest.java
@@ -1,0 +1,53 @@
+package at.aau.serg.websocketdemoserver.lobby;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LobbyRejoinTest {
+
+    @Test
+    void testRejoinUserAddsUserBack() {
+        User host = new User("1", "Host");
+        Lobby lobby = new Lobby("TestLobby", host);
+        User user = new User("2", "Stefan");
+
+        lobby.rejoinUser(user);
+        assertTrue(lobby.getUsers().stream().anyMatch(u -> u.id().equals("2")));
+    }
+
+    @Test
+    void testRejoinUserPreservesReadyStatus() {
+        User host = new User("1", "Host");
+        Lobby lobby = new Lobby("TestLobby", host);
+        User user = new User("2", "Stefan");
+
+        lobby.addUser(user);
+        lobby.markPlayerReady("2");
+
+        lobby.rejoinUser(user);
+        assertTrue(lobby.getReadyStatus().get("2"));
+    }
+
+    @Test
+    void testRejoinUserPreservesRole() {
+        User host = new User("1", "Host");
+        Lobby lobby = new Lobby("TestLobby", host);
+        User user = new User("2", "Stefan");
+
+        lobby.addUser(user);
+        lobby.selectRole("2", Role.MRX);
+
+        lobby.rejoinUser(user);
+        assertEquals(Role.MRX, lobby.getSelectedRole("2"));
+    }
+
+    @Test
+    void testRejoinUserSetsDefaultsForNewUser() {
+        User host = new User("1", "Host");
+        Lobby lobby = new Lobby("TestLobby", host);
+        User user = new User("2", "Stefan");
+
+        lobby.rejoinUser(user);
+        assertEquals(Role.NONE, lobby.getSelectedRole("2"));
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/service/LobbyServiceRejoinTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/service/LobbyServiceRejoinTest.java
@@ -1,0 +1,39 @@
+package at.aau.serg.websocketdemoserver.service;
+
+import at.aau.serg.websocketdemoserver.lobby.Lobby;
+import at.aau.serg.websocketdemoserver.lobby.User;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class LobbyServiceRejoinTest {
+
+    @Test
+    void testRejoinLobbySucceedsForExistingUser() {
+        LobbyService service = new LobbyService();
+        User host = new User("1", "Host");
+        Lobby lobby = service.createLobby("TestLobby", host);
+
+        Lobby result = service.rejoinLobby(lobby.getId(), host);
+        assertNotNull(result);
+        assertEquals(lobby.getId(), result.getId());
+    }
+
+    @Test
+    void testRejoinLobbyThrowsForUnknownLobby() {
+        LobbyService service = new LobbyService();
+        User user = new User("1", "Stefan");
+        assertThrows(IllegalArgumentException.class,
+                () -> service.rejoinLobby("UNKNOWN_LOBBY_ID", user));
+    }
+
+    @Test
+    void testRejoinLobbyAddsNewUserToLobby() {
+        LobbyService service = new LobbyService();
+        User host = new User("1", "Host");
+        Lobby lobby = service.createLobby("TestLobby", host);
+        User newUser = new User("2", "Stefan");
+
+        Lobby result = service.rejoinLobby(lobby.getId(), newUser);
+        assertTrue(result.getUsers().stream().anyMatch(u -> u.id().equals("2")));
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/service/LobbyServiceTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/service/LobbyServiceTest.java
@@ -59,12 +59,13 @@ public class LobbyServiceTest {
     }
 
     @Test
-    void testJoinLobbyFailsIfUserAlreadyInLobby() {
+    void testJoinLobbyReturnsExistingOnReconnect() {
         LobbyService service = new LobbyService();
         User host = new User("1", "Host");
         Lobby lobby = service.createLobby("TestLobby", host);
 
-        assertThrows(IllegalStateException.class, () -> service.joinLobby(lobby.getId(), host));
+        Lobby result = service.joinLobby(lobby.getId(), host);
+        assertEquals(lobby.getId(), result.getId());
     }
 
     @Test

--- a/src/test/java/at/aau/serg/websocketdemoserver/service/PlayerSessionServiceTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/service/PlayerSessionServiceTest.java
@@ -1,0 +1,82 @@
+package at.aau.serg.websocketdemoserver.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayerSessionServiceTest {
+
+    private PlayerSessionService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PlayerSessionService();
+    }
+
+    @Test
+    void testPlayerJoinedLobby() {
+        service.playerJoinedLobby("user1", "lobby1");
+        assertEquals("lobby1", service.getLobbyForPlayer("user1"));
+        assertTrue(service.isPlayerInLobby("user1"));
+    }
+
+    @Test
+    void testPlayerJoinedGame() {
+        service.playerJoinedGame("user1", "game1");
+        assertEquals("game1", service.getGameForPlayer("user1"));
+        assertTrue(service.isPlayerInGame("user1"));
+    }
+
+    @Test
+    void testPlayerLeftLobby() {
+        service.playerJoinedLobby("user1", "lobby1");
+        service.playerLeftLobby("user1");
+        assertNull(service.getLobbyForPlayer("user1"));
+        assertFalse(service.isPlayerInLobby("user1"));
+    }
+
+    @Test
+    void testPlayerLeftGame() {
+        service.playerJoinedGame("user1", "game1");
+        service.playerLeftGame("user1");
+        assertNull(service.getGameForPlayer("user1"));
+        assertFalse(service.isPlayerInGame("user1"));
+    }
+
+    @Test
+    void testPlayerFullyLeft() {
+        service.playerJoinedLobby("user1", "lobby1");
+        service.playerJoinedGame("user1", "game1");
+        service.playerFullyLeft("user1");
+        assertNull(service.getLobbyForPlayer("user1"));
+        assertNull(service.getGameForPlayer("user1"));
+    }
+
+    @Test
+    void testGetLobbyForUnknownUser() {
+        assertNull(service.getLobbyForPlayer("unknown"));
+        assertFalse(service.isPlayerInLobby("unknown"));
+    }
+
+    @Test
+    void testGetGameForUnknownUser() {
+        assertNull(service.getGameForPlayer("unknown"));
+        assertFalse(service.isPlayerInGame("unknown"));
+    }
+
+    @Test
+    void testOverwriteLobbyId() {
+        service.playerJoinedLobby("user1", "lobby1");
+        service.playerJoinedLobby("user1", "lobby2");
+        assertEquals("lobby2", service.getLobbyForPlayer("user1"));
+    }
+
+    @Test
+    void testPlayerDisconnected() {
+        service.playerJoinedLobby("user1", "lobby1");
+        service.playerJoinedGame("user1", "game1");
+        service.playerDisconnected("user1");
+        // playerDisconnected should not crash
+        assertNotNull(service);
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/service/SessionAuthServiceTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/service/SessionAuthServiceTest.java
@@ -1,0 +1,111 @@
+package at.aau.serg.websocketdemoserver.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SessionAuthServiceTest {
+
+    private SessionAuthService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SessionAuthService();
+    }
+
+    @Test
+    void testBindAndGet() {
+        service.bindSession("sess1", "user1");
+        assertEquals("user1", service.getUserForSession("sess1"));
+    }
+
+    @Test
+    void testBindWithNullSession() {
+        service.bindSession(null, "user1");
+        assertEquals(0, service.getSessionCount());
+    }
+
+    @Test
+    void testBindWithNullUserId() {
+        service.bindSession("sess1", null);
+        assertEquals(0, service.getSessionCount());
+    }
+
+    @Test
+    void testGetForNullSession() {
+        assertNull(service.getUserForSession(null));
+    }
+
+    @Test
+    void testGetForUnknownSession() {
+        assertNull(service.getUserForSession("unknown"));
+    }
+
+    @Test
+    void testUnbindSession() {
+        service.bindSession("sess1", "user1");
+        service.unbindSession("sess1");
+        assertNull(service.getUserForSession("sess1"));
+    }
+
+    @Test
+    void testUnbindNullSession() {
+        service.unbindSession(null);
+        assertEquals(0, service.getSessionCount());
+    }
+
+    @Test
+    void testIsAuthorizedReturnsTrueForMatchingSession() {
+        service.bindSession("sess1", "user1");
+        assertTrue(service.isAuthorized("sess1", "user1"));
+    }
+
+    @Test
+    void testIsAuthorizedReturnsFalseForMismatchedSession() {
+        service.bindSession("sess1", "user1");
+        assertFalse(service.isAuthorized("sess1", "user2"));
+    }
+
+    @Test
+    void testIsAuthorizedReturnsTrueForNullSession() {
+        assertTrue(service.isAuthorized(null, "user1"));
+    }
+
+    @Test
+    void testIsAuthorizedReturnsFalseForNullUserId() {
+        service.bindSession("sess1", "user1");
+        assertFalse(service.isAuthorized("sess1", null));
+    }
+
+    @Test
+    void testIsAuthorizedReturnsFalseForUnknownSession() {
+        assertFalse(service.isAuthorized("unknownSess", "user1"));
+    }
+
+    @Test
+    void testMultipleSessionsForDifferentUsers() {
+        service.bindSession("sess1", "user1");
+        service.bindSession("sess2", "user2");
+        assertTrue(service.isAuthorized("sess1", "user1"));
+        assertTrue(service.isAuthorized("sess2", "user2"));
+        assertFalse(service.isAuthorized("sess1", "user2"));
+        assertFalse(service.isAuthorized("sess2", "user1"));
+    }
+
+    @Test
+    void testRebindSessionOverwrites() {
+        service.bindSession("sess1", "user1");
+        service.bindSession("sess1", "user2");
+        assertEquals("user2", service.getUserForSession("sess1"));
+    }
+
+    @Test
+    void testSessionCount() {
+        assertEquals(0, service.getSessionCount());
+        service.bindSession("sess1", "user1");
+        service.bindSession("sess2", "user2");
+        assertEquals(2, service.getSessionCount());
+        service.unbindSession("sess1");
+        assertEquals(1, service.getSessionCount());
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/service/UserServiceTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/service/UserServiceTest.java
@@ -40,11 +40,11 @@ public class UserServiceTest {
     }
 
     @Test
-    void testRegisterUserThrowsExceptionIfNameTakenCaseInsensitive() {
+    void testRegisterUserReturnsExistingUserOnReconnect() {
         userService.registerUser("Stefan");
 
-        assertThrows(IllegalArgumentException.class, () -> userService.registerUser("stefan"));
-        assertThrows(IllegalArgumentException.class, () -> userService.registerUser("STEFAN"));
+        assertNotNull(userService.registerUser("stefan"));
+        assertNotNull(userService.registerUser("STEFAN"));
     }
 
     @Test

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerRejoinTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerRejoinTest.java
@@ -21,23 +21,6 @@ class WebSocketBrokerControllerRejoinTest {
         controller = new WebSocketBrokerController(messagingTemplate);
     }
 
-    private UserConnectResponse registerUser(String nickname) {
-        UserConnectMessage uc = new UserConnectMessage();
-        uc.setNickName(nickname);
-        return controller.handleUserConnect(uc);
-    }
-
-    private String createLobbyAndReturnId(String hostId, String hostNickname) {
-        CreateLobbyMessage create = new CreateLobbyMessage();
-        create.setLobbyName("TestLobby");
-        create.setUserId(hostId);
-        create.setNickName(hostNickname);
-        controller.handleCreateLobby(create);
-        // The controller broadcasts the lobby - we cannot easily get the ID here
-        // Use a workaround by looking at the controller's internal state via service
-        return null; // We'll test by rejoin with userId tracking
-    }
-
     @Test
     void testHandleRejoinLobbyUnknownLobby() {
         RejoinLobbyMessage msg = new RejoinLobbyMessage();
@@ -64,6 +47,14 @@ class WebSocketBrokerControllerRejoinTest {
     }
 
     @Test
+    void testHandleRejoinGameWithBlankGameId() {
+        RejoinGameMessage msg = new RejoinGameMessage();
+        msg.setGameId("");
+        msg.setUserId("user1");
+        assertDoesNotThrow(() -> controller.handleRejoinGame(msg));
+    }
+
+    @Test
     void testHandleKickPlayerInGameUnknownGame() {
         KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
         msg.setGameId("UNKNOWN");
@@ -73,42 +64,76 @@ class WebSocketBrokerControllerRejoinTest {
     }
 
     @Test
-    void testRejoinLobbyAfterRegisterAndCreate() {
-        UserConnectResponse host = registerUser("HostUser");
-        CreateLobbyMessage create = new CreateLobbyMessage();
-        create.setLobbyName("TestLobby");
-        create.setUserId(host.getUser().id());
-        create.setNickName("HostUser");
-        controller.handleCreateLobby(create);
-
-        RejoinLobbyMessage rejoin = new RejoinLobbyMessage();
-        rejoin.setLobbyId("anything");
-        rejoin.setUserId(host.getUser().id());
-        rejoin.setNickName("HostUser");
-        assertDoesNotThrow(() -> controller.handleRejoinLobby(rejoin));
-    }
-
-    @Test
-    void testKickPlayerNoSession() {
+    void testHandleKickPlayerInGameWithNullGameId() {
         KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
-        msg.setGameId("");
+        msg.setGameId(null);
         msg.setRequesterId("host1");
         msg.setTargetId("target1");
         assertDoesNotThrow(() -> controller.handleKickPlayerInGame(msg));
     }
 
     @Test
-    void testMultipleRejoinAttemptsForSameUser() {
-        UserConnectResponse user = registerUser("Stefan");
-        RejoinLobbyMessage rejoin = new RejoinLobbyMessage();
-        rejoin.setLobbyId("unknown");
-        rejoin.setUserId(user.getUser().id());
-        rejoin.setNickName("Stefan");
+    void testRejoinLobbyAfterRegisterAndCreate() {
+        UserConnectMessage uc = new UserConnectMessage();
+        uc.setNickName("hostxyz");
+        UserConnectResponse host = controller.handleUserConnect(uc);
+        assertNotNull(host.getUser(), "user registration should succeed");
 
-        assertDoesNotThrow(() -> {
-            controller.handleRejoinLobby(rejoin);
-            controller.handleRejoinLobby(rejoin);
-            controller.handleRejoinLobby(rejoin);
-        });
+        CreateLobbyMessage create = new CreateLobbyMessage();
+        create.setLobbyName("TestLobby");
+        create.setUserId(host.getUser().id());
+        create.setNickName("hostxyz");
+        controller.handleCreateLobby(create);
+
+        RejoinLobbyMessage rejoin = new RejoinLobbyMessage();
+        rejoin.setLobbyId("anything");
+        rejoin.setUserId(host.getUser().id());
+        rejoin.setNickName("hostxyz");
+        assertDoesNotThrow(() -> controller.handleRejoinLobby(rejoin));
+    }
+
+    @Test
+    void testRejoinGameAfterCreateLobby() {
+        UserConnectMessage uc = new UserConnectMessage();
+        uc.setNickName("hostzzz");
+        UserConnectResponse host = controller.handleUserConnect(uc);
+        assertNotNull(host.getUser());
+
+        CreateLobbyMessage create = new CreateLobbyMessage();
+        create.setLobbyName("TestLobby2");
+        create.setUserId(host.getUser().id());
+        create.setNickName("hostzzz");
+        controller.handleCreateLobby(create);
+
+        RejoinGameMessage msg = new RejoinGameMessage();
+        msg.setGameId(null);
+        msg.setUserId(host.getUser().id());
+        assertDoesNotThrow(() -> controller.handleRejoinGame(msg));
+    }
+
+    @Test
+    void testKickPlayerWithEmptyIds() {
+        KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
+        msg.setGameId("");
+        msg.setRequesterId("");
+        msg.setTargetId("");
+        assertDoesNotThrow(() -> controller.handleKickPlayerInGame(msg));
+    }
+
+    @Test
+    void testRejoinGameForUnknownUser() {
+        RejoinGameMessage msg = new RejoinGameMessage();
+        msg.setGameId(null);
+        msg.setUserId("completelyUnknownUserABC");
+        assertDoesNotThrow(() -> controller.handleRejoinGame(msg));
+    }
+
+    @Test
+    void testRejoinLobbyWithEmptyMessage() {
+        RejoinLobbyMessage msg = new RejoinLobbyMessage();
+        msg.setLobbyId("");
+        msg.setUserId("");
+        msg.setNickName("");
+        assertDoesNotThrow(() -> controller.handleRejoinLobby(msg));
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerRejoinTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerRejoinTest.java
@@ -2,10 +2,7 @@ package at.aau.serg.websocketdemoserver.websocket.broker;
 
 import at.aau.serg.websocketdemoserver.dtos.game.KickPlayerInGameMessage;
 import at.aau.serg.websocketdemoserver.dtos.game.RejoinGameMessage;
-import at.aau.serg.websocketdemoserver.dtos.lobby.RejoinLobbyMessage;
-import at.aau.serg.websocketdemoserver.dtos.lobby.CreateLobbyMessage;
-import at.aau.serg.websocketdemoserver.dtos.lobby.UserConnectMessage;
-import at.aau.serg.websocketdemoserver.dtos.lobby.UserConnectResponse;
+import at.aau.serg.websocketdemoserver.dtos.lobby.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -24,14 +21,29 @@ class WebSocketBrokerControllerRejoinTest {
         controller = new WebSocketBrokerController(messagingTemplate);
     }
 
+    private UserConnectResponse registerUser(String nickname) {
+        UserConnectMessage uc = new UserConnectMessage();
+        uc.setNickName(nickname);
+        return controller.handleUserConnect(uc);
+    }
+
+    private String createLobbyAndReturnId(String hostId, String hostNickname) {
+        CreateLobbyMessage create = new CreateLobbyMessage();
+        create.setLobbyName("TestLobby");
+        create.setUserId(hostId);
+        create.setNickName(hostNickname);
+        controller.handleCreateLobby(create);
+        // The controller broadcasts the lobby - we cannot easily get the ID here
+        // Use a workaround by looking at the controller's internal state via service
+        return null; // We'll test by rejoin with userId tracking
+    }
+
     @Test
     void testHandleRejoinLobbyUnknownLobby() {
         RejoinLobbyMessage msg = new RejoinLobbyMessage();
         msg.setLobbyId("UNKNOWN");
         msg.setUserId("user1");
         msg.setNickName("Stefan");
-
-        // Should not throw, just send error
         assertDoesNotThrow(() -> controller.handleRejoinLobby(msg));
     }
 
@@ -40,7 +52,14 @@ class WebSocketBrokerControllerRejoinTest {
         RejoinGameMessage msg = new RejoinGameMessage();
         msg.setGameId("UNKNOWN");
         msg.setUserId("user1");
+        assertDoesNotThrow(() -> controller.handleRejoinGame(msg));
+    }
 
+    @Test
+    void testHandleRejoinGameWithNullGameId() {
+        RejoinGameMessage msg = new RejoinGameMessage();
+        msg.setGameId(null);
+        msg.setUserId("user1");
         assertDoesNotThrow(() -> controller.handleRejoinGame(msg));
     }
 
@@ -50,26 +69,46 @@ class WebSocketBrokerControllerRejoinTest {
         msg.setGameId("UNKNOWN");
         msg.setRequesterId("host1");
         msg.setTargetId("target1");
-
         assertDoesNotThrow(() -> controller.handleKickPlayerInGame(msg));
     }
 
     @Test
     void testRejoinLobbyAfterRegisterAndCreate() {
-        UserConnectMessage uc = new UserConnectMessage();
-        uc.setNickName("Stefan");
-        UserConnectResponse ucResp = controller.handleUserConnect(uc);
-
+        UserConnectResponse host = registerUser("HostUser");
         CreateLobbyMessage create = new CreateLobbyMessage();
         create.setLobbyName("TestLobby");
-        create.setUserId(ucResp.getUser().id());
+        create.setUserId(host.getUser().id());
+        create.setNickName("HostUser");
         controller.handleCreateLobby(create);
 
-        // Try rejoin
         RejoinLobbyMessage rejoin = new RejoinLobbyMessage();
         rejoin.setLobbyId("anything");
-        rejoin.setUserId(ucResp.getUser().id());
-        rejoin.setNickName("Stefan");
+        rejoin.setUserId(host.getUser().id());
+        rejoin.setNickName("HostUser");
         assertDoesNotThrow(() -> controller.handleRejoinLobby(rejoin));
+    }
+
+    @Test
+    void testKickPlayerNoSession() {
+        KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
+        msg.setGameId("");
+        msg.setRequesterId("host1");
+        msg.setTargetId("target1");
+        assertDoesNotThrow(() -> controller.handleKickPlayerInGame(msg));
+    }
+
+    @Test
+    void testMultipleRejoinAttemptsForSameUser() {
+        UserConnectResponse user = registerUser("Stefan");
+        RejoinLobbyMessage rejoin = new RejoinLobbyMessage();
+        rejoin.setLobbyId("unknown");
+        rejoin.setUserId(user.getUser().id());
+        rejoin.setNickName("Stefan");
+
+        assertDoesNotThrow(() -> {
+            controller.handleRejoinLobby(rejoin);
+            controller.handleRejoinLobby(rejoin);
+            controller.handleRejoinLobby(rejoin);
+        });
     }
 }

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerRejoinTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerRejoinTest.java
@@ -1,0 +1,75 @@
+package at.aau.serg.websocketdemoserver.websocket.broker;
+
+import at.aau.serg.websocketdemoserver.dtos.game.KickPlayerInGameMessage;
+import at.aau.serg.websocketdemoserver.dtos.game.RejoinGameMessage;
+import at.aau.serg.websocketdemoserver.dtos.lobby.RejoinLobbyMessage;
+import at.aau.serg.websocketdemoserver.dtos.lobby.CreateLobbyMessage;
+import at.aau.serg.websocketdemoserver.dtos.lobby.UserConnectMessage;
+import at.aau.serg.websocketdemoserver.dtos.lobby.UserConnectResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class WebSocketBrokerControllerRejoinTest {
+
+    private SimpMessagingTemplate messagingTemplate;
+    private WebSocketBrokerController controller;
+
+    @BeforeEach
+    void setUp() {
+        messagingTemplate = mock(SimpMessagingTemplate.class);
+        controller = new WebSocketBrokerController(messagingTemplate);
+    }
+
+    @Test
+    void testHandleRejoinLobbyUnknownLobby() {
+        RejoinLobbyMessage msg = new RejoinLobbyMessage();
+        msg.setLobbyId("UNKNOWN");
+        msg.setUserId("user1");
+        msg.setNickName("Stefan");
+
+        // Should not throw, just send error
+        assertDoesNotThrow(() -> controller.handleRejoinLobby(msg));
+    }
+
+    @Test
+    void testHandleRejoinGameUnknownGame() {
+        RejoinGameMessage msg = new RejoinGameMessage();
+        msg.setGameId("UNKNOWN");
+        msg.setUserId("user1");
+
+        assertDoesNotThrow(() -> controller.handleRejoinGame(msg));
+    }
+
+    @Test
+    void testHandleKickPlayerInGameUnknownGame() {
+        KickPlayerInGameMessage msg = new KickPlayerInGameMessage();
+        msg.setGameId("UNKNOWN");
+        msg.setRequesterId("host1");
+        msg.setTargetId("target1");
+
+        assertDoesNotThrow(() -> controller.handleKickPlayerInGame(msg));
+    }
+
+    @Test
+    void testRejoinLobbyAfterRegisterAndCreate() {
+        UserConnectMessage uc = new UserConnectMessage();
+        uc.setNickName("Stefan");
+        UserConnectResponse ucResp = controller.handleUserConnect(uc);
+
+        CreateLobbyMessage create = new CreateLobbyMessage();
+        create.setLobbyName("TestLobby");
+        create.setUserId(ucResp.getUser().id());
+        controller.handleCreateLobby(create);
+
+        // Try rejoin
+        RejoinLobbyMessage rejoin = new RejoinLobbyMessage();
+        rejoin.setLobbyId("anything");
+        rejoin.setUserId(ucResp.getUser().id());
+        rejoin.setNickName("Stefan");
+        assertDoesNotThrow(() -> controller.handleRejoinLobby(rejoin));
+    }
+}

--- a/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
+++ b/src/test/java/at/aau/serg/websocketdemoserver/websocket/broker/WebSocketBrokerControllerTest.java
@@ -561,7 +561,7 @@ class WebSocketBrokerControllerTest {
     }
 
     @Test
-    void testHandleUserConnect_duplicateNickname_returnsError() {
+    void testHandleUserConnect_duplicateNickname_returnsExistingUser() {
         UserConnectMessage first = new UserConnectMessage();
         first.setNickName("dupetest");
         controller.handleUserConnect(first);
@@ -569,8 +569,8 @@ class WebSocketBrokerControllerTest {
         UserConnectMessage second = new UserConnectMessage();
         second.setNickName(first.getNickName());
         UserConnectResponse response = controller.handleUserConnect(second);
-        assertFalse(response.isSuccess());
-        assertEquals("Nickname already taken", response.getMessage());
+        assertTrue(response.isSuccess());
+        assertEquals("dupetest", response.getUser().nickName());
     }
 
     @Test


### PR DESCRIPTION
Adds rejoin endpoints for lobby and game so players can reconnect after disconnect. PlayerSessionService tracks which user is in which lobby/game.
Also adds host kick endpoint: host can remove disconnected players from a running game. If MrX gets kicked or less than 2 players remain, the detectives win automatically.